### PR TITLE
Feature/gridfs attachments

### DIFF
--- a/importTools/elog/collect_authors.py
+++ b/importTools/elog/collect_authors.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+DEFAULT_SEP = " : "
+
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Collect authors from an elog dump ...")
+
+parser.add_argument("-d", "--dump", default="dump", help="Folder containing the elog dump")
+parser.add_argument("-o", "--output", default="authors", help="Output file name")
+parser.add_argument("-s", "--separator", default=DEFAULT_SEP, help=f"Key-value separator in the output (default: \"{DEFAULT_SEP}\")")
+parser.add_argument("-p", "--print", action="store_true", help="Print authors")
+
+clargs = parser.parse_args()
+
+
+
+from pathlib import Path
+import json
+
+
+def collect(folder):
+    dump = Path(folder)
+    fns = dump.glob("msg*.json")
+    authors = set()
+    for fn in sorted(fns):
+        data = json_load(fn)
+        author = data["Author"]
+        authors.add(author)
+
+    authors = sorted(authors)
+    return authors
+
+
+def check(authors, print_all=False):
+    for a in authors:
+        if print_all:
+            print(a)
+
+        stripped_author = a.strip()
+        if a != stripped_author:
+            print(f"Warning: Author \"{author}\" has strippable spaces.")
+
+        if a == "":
+            print("Warning: Author is the empty string.")
+
+
+def save(authors, output, sep):
+    data = [f"{a}{sep}" for a in authors]
+    text_save(data, output)
+
+
+def json_load(fname):
+    with open(fname, "r") as f:
+        return json.load(f)
+
+def text_save(data, fname):
+    with open(fname, "w") as f:
+        for line in data:
+            f.write(line)
+            f.write("\n")
+
+
+
+
+
+if __name__ == "__main__":
+    authors = collect(clargs.dump)
+    check(authors, clargs.print)
+    save(authors, clargs.output, clargs.separator)
+
+
+

--- a/importTools/elog/convert_authors.py
+++ b/importTools/elog/convert_authors.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+DEFAULT_SEP = " : "
+
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Convert collected and mapped authors to json ...")
+
+parser.add_argument("-i", "--input", default="authors", help="Input file name")
+parser.add_argument("-o", "--output", default="authors.json", help="Output file name")
+parser.add_argument("-s", "--separator", default=DEFAULT_SEP, help=f"Key-value separator in the output (default: \"{DEFAULT_SEP}\")")
+parser.add_argument("-d", "--default", help="Default user")
+parser.add_argument("-p", "--print", action="store_true", help="Print authors")
+
+clargs = parser.parse_args()
+
+
+
+from pathlib import Path
+import json
+
+
+def author_load(fname, sep, default):
+    data = text_load(fname)
+    res = {}
+    for line in data:
+        line = line.split(sep)
+        old, new = line
+        if new == "":
+            print(f"Warning: will use default ({default}) for author \"{old}\".")
+            new = default
+        res[old] = new
+    return res
+
+def text_load(fname):
+    res = []
+    with open(fname, "r") as f:
+        for line in f:
+            line = line.split("#")[0] # remove comments
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            res.append(line)
+    return res
+
+def print_dict(d):
+    length = maxstrlen(d.keys())
+    for k, v in d.items():
+        print(k.rjust(length), "->", v)
+
+def maxstrlen(seq):
+    return max(strlen(i) for i in seq)
+
+def strlen(val):
+    return len(str(val))
+
+def json_dump(data, fname):
+    with open(fname, "w") as f:
+        json.dump(data, f, sort_keys=True, indent=4)
+
+
+
+
+
+if __name__ == "__main__":
+    author_map = author_load(clargs.input, clargs.separator, clargs.default)
+    if clargs.print:
+        print_dict(author_map)
+    json_dump(author_map, clargs.output)
+
+
+

--- a/importTools/elog/e2sci.py
+++ b/importTools/elog/e2sci.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+
+from glob import iglob
+import json
+import uuid
+
+def json_load(filename, *args, **kwargs):
+    with open(filename, "r") as f:
+        return json.load(f, *args, **kwargs)
+
+def json_save(what, filename, *args, indent=4, sort_keys=True, **kwargs):
+    with open(filename, "w") as f:
+        json.dump(what, f, *args, indent=indent, sort_keys=sort_keys, **kwargs)
+
+
+
+
+default_pgroup = "default"
+default_author = "default"
+
+
+mapped = {
+#    "Author": "createdBy",
+    "Date": "timestamp",
+#    "message": "textcontent",
+#    "P-Group": "ownerGroup"
+}
+
+ignored = [
+    "Encoding", # seems to be always HTML
+    "MID", # message ID
+    "Section", # seems to be always the endstation
+    "When" # unclear how this differs from Date
+]
+
+special = [
+    "Author",
+    "attachments",
+    "P-Group",
+    "message",
+    "Title"
+]
+
+tags = [
+    "Component",
+    "Entry",
+    "System",
+
+    "Category",
+    "Domain",
+    "Effect",
+    "Valid until",
+    "Group",
+    "Type"
+]
+
+
+authors = json_load("authors.json")
+
+fns = sorted(iglob("dump/msg*.json"))
+res = []
+for fn in fns:
+    data_out = {}
+    data_in = json_load(fn)
+
+    for k, v in data_in.items():
+        if k in mapped or k in ignored or k in special or k in tags:
+            continue
+        print(fn, "has unassigned key:", k, "=", repr(v))
+
+    # remove ignored entries
+    for i in ignored:
+        data_in.pop(i)
+
+    # copy mapped entries
+    tmp = {o: data_in.pop(i) for i, o in mapped.items()}
+    tmp = {k: v for k, v in tmp.items() if v}
+    data_out.update(tmp)
+
+    # make tags
+    tmp = [data_in.pop(t, None) for t in tags]
+    tmp = [i for i in tmp if i]
+    if tmp:
+        data_out["tags"] = tmp
+
+    # treat special entries
+    author = data_in.pop("Author")
+    author = authors.get(author, default_author)
+    data_out["createdBy"] = author
+
+    pgroup = data_in.pop("P-Group", default_pgroup)
+    data_out["ownerGroup"] = pgroup
+
+    data_out["accessGroups"] = [author, pgroup]
+
+
+    mesg = data_in.pop("message")
+    title = data_in.pop("Title")
+    title = title.strip()
+    title = f"<p><h3>{title}</h3></p>"
+
+    textcontent = title + mesg
+    files = []
+
+    attchs = data_in.pop("attachments")
+    if attchs:
+        for fn in attchs:
+            f_hash = str(uuid.uuid4())
+            f_id = str(uuid.uuid4())
+            filepath = f"./dump/attachments/{fn}"
+            f_ext = fn.split(".")[-1]
+            textcontent += (
+                f'<p><a class="fileLink" target="_blank" href="file:{f_hash}">{fn}</a></p>'
+            )
+            files.append({"fileHash": f_hash, "fileId": f_id, "fileExtension": f"file/{f_ext}", "filepath": filepath})
+
+    data_out["textcontent"] = textcontent
+    data_out["files"] = files
+
+    if data_in:
+        raise ValueError(f"there are unassigned entries in \"{fn}\": {data_in}")
+
+    data_out["snippetType"] = data_out["linkType"] = "paragraph"
+
+    res.append(data_out)
+
+
+json_save(res, "scilog.json")
+
+
+

--- a/importTools/elog/e2sci.py
+++ b/importTools/elog/e2sci.py
@@ -3,6 +3,7 @@
 import json
 import os
 from glob import iglob
+from datetime import datetime
 
 from scilog.scilog import SciLog
 
@@ -17,22 +18,21 @@ def json_save(what, filename, *args, indent=4, sort_keys=True, **kwargs):
         json.dump(what, f, *args, indent=indent, sort_keys=sort_keys, **kwargs)
 
 
-default_pgroup = "default"
-default_author = "default"
+default_pgroup = "any-authenticated-user"
+default_author = "unknown@domain.org"
 
 
 mapped = {
-    #    "Author": "createdBy",
-    "Date": "timestamp",
-    #    "message": "textcontent",
-    #    "P-Group": "ownerGroup"
+    "Date": "createdAt",
 }
 
 ignored = [
     "Encoding",  # seems to be always HTML
     "MID",  # message ID
-    "Section",  # seems to be always the endstation
+    # "Section",  # seems to be always the endstation
     "When",  # unclear how this differs from Date
+    "Reply to", # for now ignored
+    "In reply to" # for now ignored
 ]
 
 special = ["Author", "attachments", "P-Group", "message", "Title"]
@@ -41,22 +41,46 @@ tags = [
     "Component",
     "Entry",
     "System",
+    "Subsystem",
     "Category",
     "Domain",
     "Effect",
     "Valid until",
     "Group",
     "Type",
+    "Subject",
+    "Section",
 ]
 
 
 authors = json_load("authors.json")
 
-dump_path = "./elogdump/"
+dump_path = "./"
 
 fns = sorted(iglob(f"{dump_path}/dump/msg*.json"))
 res = []
+ranges=[
+    {"pgroup":"p18539", "start": 269,   "end": 2132 },
+    {"pgroup":"p18713", "start": 2584,  "end": 3564 },
+    {"pgroup":"p18711", "start": 3639,  "end": 3989 },
+    {"pgroup":"p18763", "start": 4808,  "end": 5137 },
+    {"pgroup":"p18915", "start": 5289,  "end": 6135 },
+    {"pgroup":"p19160", "start": 6824,  "end": 7707 },
+    {"pgroup":"p19303", "start": 8081,  "end": 8591 },
+    {"pgroup":"p19318", "start": 8644,  "end": 9046 },
+    {"pgroup":"p19319", "start": 9149,  "end": 9664 },
+    {"pgroup":"p19320", "start": 9850,  "end": 10290 },
+    {"pgroup":"p19321", "start": 10437, "end": 11009 },
+    {"pgroup":"p19525", "start": 11425, "end": 12090 },
+    {"pgroup":"p19704", "start": 12735, "end": 13219 },
+    {"pgroup":"p19740", "start": 14065, "end": 14412 },
+    {"pgroup":"p19741", "start": 14443, "end": 15178 },
+    {"pgroup":"p19742", "start": 15193, "end": 15906 },
+    {"pgroup":"p20230", "start": 15908, "end": 16446 },
+]
+
 for fn in fns:
+    print(fn)
     data_out = {}
     data_in = json_load(fn)
 
@@ -65,14 +89,25 @@ for fn in fns:
             continue
         print(fn, "has unassigned key:", k, "=", repr(v))
 
+    # check the chosen range
+    for range in ranges:
+        if range["start"] <= data_in["MID"] <= range["end"]:
+            default_pgroup= range["pgroup"]
+            break
+
     # remove ignored entries
     for i in ignored:
-        data_in.pop(i)
+        data_in.pop(i,None)
 
     # copy mapped entries
     tmp = {o: data_in.pop(i) for i, o in mapped.items()}
     tmp = {k: v for k, v in tmp.items() if v}
     data_out.update(tmp)
+
+    #convert date info
+    tdate=datetime.strptime(data_out["createdAt"], '%a, %d %b %Y %H:%M:%S %z')
+    data_out["createdAt"]=datetime.strftime(tdate, "%Y-%m-%dT%H:%M:%S%z")
+    data_out["updatedAt"]=data_out["createdAt"]
 
     # make tags
     tmp = [data_in.pop(t, None) for t in tags]
@@ -81,17 +116,22 @@ for fn in fns:
         data_out["tags"] = tmp
 
     # treat special entries
+       # treat special entries
     author = data_in.pop("Author")
     author = authors.get(author, default_author)
     data_out["createdBy"] = author
+    data_out["updatedBy"] = author
+
 
     pgroup = data_in.pop("P-Group", default_pgroup)
     data_out["ownerGroup"] = pgroup
 
-    data_out["accessGroups"] = [author, pgroup]
+    data_out["accessGroups"] = []
 
     mesg = data_in.pop("message")
-    title = data_in.pop("Title")
+    title = data_in.pop("Title",None)
+    if title == None:
+        title=""
     title = title.strip()
     title = f"<p><h3>{title}</h3></p>"
 
@@ -110,7 +150,7 @@ for fn in fns:
     data_out["files"] = files
 
     if data_in:
-        raise ValueError(f'there are unassigned entries in "{fn}": {data_in}')
+        raise ValueError(f"there are unassigned entries in {fn}: {data_in}")
 
     data_out["snippetType"] = data_out["linkType"] = "paragraph"
 

--- a/importTools/elog/elogdump.py
+++ b/importTools/elog/elogdump.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import imghdr
 
 parser = argparse.ArgumentParser(
     description="Dump an elog ...",
@@ -55,6 +56,7 @@ class ELogScraper:
 
         mids = self.lb.get_message_ids()
         self.mids = sorted(mids)
+        # to selectively dump messages: self.mids = sorted(i for i in mids if i <= 13120)
         self.nmsgs = nmsgs = len(mids)
         self.counter_width = len(str(nmsgs))
 
@@ -130,8 +132,8 @@ def sanitize_attributes(i, attributes):
     return attributes
 
 def sanitize_attachments(attachments, url):
-    if attachments == [url]: #TODO: WTF?!
-        attachments = []
+#    if attachments == [url]: #TODO: WTF?!
+#        attachments = []
     return attachments
 
 def build_entry(i, message, attributes, attachments):
@@ -159,8 +161,15 @@ class FileDownloader:
     def get_file(self, url):
         fname = extract_filename(url)
         full_fname = os.path.join(self.folder, fname)
-#        print(f"{url} -> {fname}")
-        download(url, full_fname)
+        # fix missing extensions here
+        if fname != "":
+            pathname, extension = os.path.splitext(fname)
+            if extension== '' :
+                extension='png' # for now assume its a png file, TODO imghdr.what(attachment)
+                fname=pathname+'.'+extension
+                print(f"After =========== {fname}")
+            print(f"{url} -> {fname}")
+            download(url, full_fname)
         return fname
 
 
@@ -173,6 +182,7 @@ def extract_filename(url):
 
 def download(url, fname):
     with http.request("GET", url, preload_content=False) as resp:
+        print(f"{url} -> {fname}")
         with open(fname, "wb") as f:
             shutil.copyfileobj(resp, f)
     resp.release_conn()

--- a/importTools/elog/elogdump.py
+++ b/importTools/elog/elogdump.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+
+import argparse
+
+parser = argparse.ArgumentParser(
+    description="Dump an elog ...",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+
+parser.add_argument("url", help="elog URL, e.g., https://elog-gfa.psi.ch/SwissFEL+test/")
+parser.add_argument("-o", "--output", default="dump", help="Output folder")
+parser.add_argument("-a", "--attachments", default="attachments",
+    help="Attachments sub-folder relative to the output folder"
+)
+
+clargs = parser.parse_args()
+
+
+
+import builtins
+import functools
+import json
+import os
+import shutil
+
+from tqdm import tqdm
+import elog
+import urllib3
+
+
+# Certs are not valid...
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+http = urllib3.PoolManager(cert_reqs="CERT_NONE")
+
+
+
+# HTML messages contain some code-formatting characters
+FORMATTING_CHARS = ["\n", "\t"]
+
+
+
+class ELogScraper:
+
+    def __init__(self, url, output_folder=".", attachment_subfolder="attachments"):
+        self.url = url = url if url.endswith("/") else url + "/" #TODO: only needed for attachments bug!
+
+        self.output_folder = output_folder
+        mkdirs(output_folder)
+
+        self.attachment_folder = attachment_folder = os.path.join(output_folder, attachment_subfolder)
+        self.fd = FileDownloader(attachment_folder)
+
+        self.lb = elog.open(url)
+        self.elog_read = retry(self.lb.read)
+
+        mids = self.lb.get_message_ids()
+        self.mids = sorted(mids)
+        self.nmsgs = nmsgs = len(mids)
+        self.counter_width = len(str(nmsgs))
+
+
+    def dump(self):
+        print()
+        print(f"Dumping {self.nmsgs} messages from {self.url}")
+        print(f"- Messages to:    {self.output_folder}")
+        print(f"- Attachments to: {self.attachment_folder}")
+        print()
+        try:
+            builtins.print = tqdm.write # otherwise print() breaks tqdm
+            for msg in tqdm(self.get_entries(), total=self.nmsgs):
+                pass
+        except KeyboardInterrupt:
+            raise SystemExit(f"\nDump not finished! You might want to delete the \"{output}\" folder.")
+        finally:
+            builtins.print = print
+
+
+    def get_entries(self):
+        for i in self.mids:
+            yield self.get_entry(i)
+
+
+    def get_entry(self, index):
+        message, attributes, attachments = self.elog_read(index)
+        message = sanitize_message(message)
+        attributes = sanitize_attributes(index, attributes)
+        attachments = sanitize_attachments(attachments, self.url)
+        fns = self.fd.get(attachments)
+        entry = build_entry(index, message, attributes, fns)
+
+        counter = str(index).zfill(self.counter_width)
+        fname = f"msg{counter}.json"
+        fname = os.path.join(self.output_folder, fname)
+
+        json_dump(entry, fname)
+        return entry
+
+
+
+def retry(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        n = 1
+        while True:
+            try:
+                res = func(*args, **kwargs)
+            except Exception as e:
+                print_func = func.__name__
+                all_args = [str(a) for a in args] + ["{k}={v}" for k, v in kwargs.items()]
+                print_args = ", ".join(all_args)
+                print(f"retry #{n}: {print_func}({print_args}), failed  due to:\n{e}")
+                n += 1
+            else:
+                return res
+    return wrapper
+
+def sanitize_message(message):
+    return remove_all(message, FORMATTING_CHARS)
+
+def remove_all(s, chars):
+    for c in chars:
+        s = s.replace(c, "")
+    return s
+
+def sanitize_attributes(i, attributes):
+    mid = attributes.pop("$@MID@$")
+    mid = int(mid)
+    assert i == mid
+    attributes["MID"] = i
+    return attributes
+
+def sanitize_attachments(attachments, url):
+    if attachments == [url]: #TODO: WTF?!
+        attachments = []
+    return attachments
+
+def build_entry(i, message, attributes, attachments):
+    entry = {}
+    entry.update(attributes)
+    entry["attachments"] = attachments
+    entry["message"] = message
+    return entry
+
+def json_dump(data, fname):
+    with open(fname, "w") as f:
+        json.dump(data, f, sort_keys=True, indent=4)
+
+
+
+class FileDownloader:
+
+    def __init__(self, folder="."):
+        self.folder = folder
+        mkdirs(folder)
+
+    def get(self, urls):
+        return [self.get_file(u) for u in urls]
+
+    def get_file(self, url):
+        fname = extract_filename(url)
+        full_fname = os.path.join(self.folder, fname)
+#        print(f"{url} -> {fname}")
+        download(url, full_fname)
+        return fname
+
+
+
+def extract_filename(url):
+    parsed_url = urllib3.util.parse_url(url)
+    path = parsed_url.path
+    fname = os.path.basename(path)
+    return fname
+
+def download(url, fname):
+    with http.request("GET", url, preload_content=False) as resp:
+        with open(fname, "wb") as f:
+            shutil.copyfileobj(resp, f)
+    resp.release_conn()
+
+def mkdirs(folder):
+    os.makedirs(folder, exist_ok=True)
+
+
+
+
+
+if __name__ == "__main__":
+    url = clargs.url
+    output = clargs.output
+    attachments = clargs.attachments
+    els = ELogScraper(url, output_folder=output, attachment_subfolder=attachments)
+    els.dump()
+
+
+

--- a/importTools/importToScilog.py
+++ b/importTools/importToScilog.py
@@ -2,11 +2,11 @@
 import argparse
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument("pgroup", help="Expected form: p12345")
+# parser.add_argument("pgroup", help="Expected form: p12345")
 parser.add_argument("-u", "--url", default="http://localhost:3000", help="Server address")
 
 clargs = parser.parse_args()
-pgroup = clargs.pgroup
+# pgroup = clargs.pgroup
 url = clargs.url
 
 
@@ -20,12 +20,7 @@ from scilog import Basesnippet, Paragraph
 import json
 
 log = SciLog(url, options={"username": "scilog-admin@psi.ch"})
-logbooks = log.get_logbooks(ownerGroup=pgroup)
 
-assert len(logbooks) >= 1
-logbook = logbooks[0]
-
-log.select_logbook(logbook)
 
 snippets = []
 with open("./elog/scilog.json", "r") as stream:
@@ -33,4 +28,11 @@ with open("./elog/scilog.json", "r") as stream:
     snippets = json.loads(content)
 
 for snippet in snippets:
+    pgroup=snippet["ownerGroup"]
+    if pgroup == "any-authenticated-user":
+        continue
+    logbooks = log.get_logbooks(ownerGroup=pgroup)
+    assert len(logbooks) >= 1
+    logbook = logbooks[0]
+    log.select_logbook(logbook)
     log.import_from_dict(snippet=snippet)

--- a/importTools/importToScilog.py
+++ b/importTools/importToScilog.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+import argparse
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument("pgroup", help="Expected form: p12345")
+parser.add_argument("-u", "--url", default="http://localhost:3000", help="Server address")
+
+clargs = parser.parse_args()
+pgroup = clargs.pgroup
+url = clargs.url
+
+
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+from scilog import SciLog
+from scilog import Basesnippet, Paragraph
+import json
+
+log = SciLog(url, options={"username": "scilog-admin@psi.ch"})
+logbooks = log.get_logbooks(ownerGroup=pgroup)
+
+assert len(logbooks) >= 1
+logbook = logbooks[0]
+
+log.select_logbook(logbook)
+
+snippets = []
+with open("./elog/scilog.json", "r") as stream:
+    content = stream.read()
+    snippets = json.loads(content)
+
+for snippet in snippets:
+    log.import_from_dict(snippet=snippet)

--- a/importTools/update_locations.py
+++ b/importTools/update_locations.py
@@ -17,7 +17,7 @@ def prepare_location_snippet(log):
 
     new_loc = {
         "ownerGroup": "admin",
-        "accessGroups": ["customer"],
+        "accessGroups": ["any-authenticated-user"],
         "isPrivate": True,
         "title": "location",
         "snippetType": "paragraph",
@@ -75,7 +75,7 @@ def _update_locations(log, loc_id, locations):
         group = loc[5:].replace("/", "").lower()
         new_snip = {
             "ownerGroup": group,
-            "accessGroups": ["customer"],
+            "accessGroups": ["any-authenticated-user"],
             "isPrivate": True,
             "title": loc.split("/")[-1],
             "location": loc,

--- a/sci-log-db/fixtures/users/02.yml
+++ b/sci-log-db/fixtures/users/02.yml
@@ -2,4 +2,4 @@ email: john@example.com
 firstName: John
 lastName: Doe
 password: john12345678
-roles: ['customer']
+roles: ['any-authenticated-user']

--- a/sci-log-db/fixtures/users/03.yml
+++ b/sci-log-db/fixtures/users/03.yml
@@ -2,4 +2,4 @@ email: jane@example.com
 firstName: Jane
 lastName: Doe
 password: jane12345678
-roles: ['customer']
+roles: ['any-authenticated-user']

--- a/sci-log-db/functionalAccounts-example.json
+++ b/sci-log-db/functionalAccounts-example.json
@@ -1,0 +1,11 @@
+[{
+    "username": "scilog-admin",
+    "firstName": "Admin",
+    "lastName": "Scilog",
+    "password": "some-strong-passw0rd",
+    "email": "scilog-admin@YOURDOMAIN",
+    "roles": [
+        "admin",
+        "any-authenticated-user"
+    ]
+}]

--- a/sci-log-db/oidc-example.json
+++ b/sci-log-db/oidc-example.json
@@ -1,0 +1,17 @@
+{
+    "session": false,
+    "provider": "oidc",
+    "authScheme": "openid connect",
+    "module": "passport-openidconnect",
+    "failureFlash": true,
+    "issuer": "https://kc.YOURDOMAIN/auth/realms/awi",
+    "authorizationURL": "https://kc.YOURDOMAIN/auth/realms/awi/protocol/openid-connect/auth",
+    "tokenURL": "https://kc.YOURDOMAIN/auth/realms/awi/protocol/openid-connect/token",
+    "userInfoURL": "https://kc.YOURDOMAIN/auth/realms/awi/protocol/openid-connect/userinfo",
+    "clientID": "scilog",
+    "clientSecret": "YOUR-CLIENT-SECRET",
+    "callbackURL": "http://localhost:3000/auth/keycloak/callback/",
+    "scope": ["email", "profile", "openid"],
+    "successRedirect": "http://localhost:4200/login",
+    "skipUserProfile": false
+}

--- a/sci-log-db/src/__tests__/acceptance/authentication.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/authentication.acceptance.ts
@@ -27,7 +27,7 @@ describe('authentication services', function (this: Suite) {
     email: 'unittest@loopback.io',
     firstName: 'unit',
     lastName: 'test',
-    roles: ['customer'],
+    roles: ['any-authenticated-user'],
   };
 
   const userPassword = 'p4ssw0rd';
@@ -120,7 +120,7 @@ describe('authentication services', function (this: Suite) {
       [securityId]: newUser.id,
       id: newUser.id,
       name: `${newUser.firstName} ${newUser.lastName}`,
-      roles: ['customer'],
+      roles: ['any-authenticated-user'],
     };
     const userProfile = userService.convertToUserProfile(newUser);
     expect(userProfile).to.deepEqual(expectedUserProfile);

--- a/sci-log-db/src/__tests__/acceptance/file.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/file.controller.acceptance.ts
@@ -90,7 +90,7 @@ describe('File controller services', function (this: Suite) {
     const postResponse = await client.post('/filesnippet/files')
       .set('Authorization', 'Bearer ' + token)
       .type('form')
-      .field('fields', '{"ownerGroup": "customer"}')
+      .field('fields', '{"ownerGroup": "any-authenticated-user"}')
       .attach('file', __filename)
       .then()
       .catch((err) => {
@@ -113,7 +113,7 @@ describe('File controller services', function (this: Suite) {
     const postResponse = await client.post('/filesnippet/files')
       .set('Authorization', 'Bearer ' + token)
       .type('form')
-      .field('fields', '{"ownerGroup": "customer"}')
+      .field('fields', '{"ownerGroup": "any-authenticated-user"}')
       .attach('file', __filename)
       .then()
       .catch((err) => {

--- a/sci-log-db/src/__tests__/acceptance/oidc.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/oidc.acceptance.ts
@@ -36,7 +36,7 @@ describe('OIDC services', function (this: Suite) {
     firstName: 'unit',
     lastName: 'test',
     username: 'unittest',
-    roles: ['aRole', 'customer', 'unittest'],
+    roles: ['aRole', 'any-authenticated-user', 'unittest'],
   };
 
   async function clearDatabase() {

--- a/sci-log-db/src/__tests__/acceptance/test-helper.ts
+++ b/sci-log-db/src/__tests__/acceptance/test-helper.ts
@@ -20,7 +20,7 @@ const userData = {
   email: 'test@loopback.io',
   firstName: 'Example',
   lastName: 'User',
-  roles: ['customer'],
+  roles: ['any-authenticated-user'],
 };
 
 export const oidcOptions = {

--- a/sci-log-db/src/__tests__/acceptance/user.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/user.controller.acceptance.ts
@@ -24,7 +24,7 @@ describe('UserController', () => {
     email: 'test@loopback.io',
     firstName: 'Example',
     lastName: 'User',
-    roles: ['customer'],
+    roles: ['any-authenticated-user'],
   };
 
   const userPassword = 'p4ssw0rd';

--- a/sci-log-db/src/authentication-strategies/types.ts
+++ b/sci-log-db/src/authentication-strategies/types.ts
@@ -67,7 +67,7 @@ export const verifyFunctionFactory = function (
       firstName: firstName,
       lastName: lastName,
       username: profile.username,
-      roles: [...profile._json.roles ?? [], 'customer', profile.username as string]
+      roles: [...profile._json.roles ?? [], 'any-authenticated-user', profile.username as string]
     }
     findOrCreateUser(userRepo, user).then((user: User) => {
       done(null, user);

--- a/sci-log-db/src/controllers/basesnippet.controller.ts
+++ b/sci-log-db/src/controllers/basesnippet.controller.ts
@@ -14,7 +14,7 @@ import {ExportService} from '../services/export-snippets.service';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 
 @authenticate('jwt')
-@authorize({allowedRoles: ['customer'], voters: [basicAuthorization]})
+@authorize({allowedRoles: ['any-authenticated-user'], voters: [basicAuthorization]})
 export class BasesnippetController {
 
   exportDir: string = "";

--- a/sci-log-db/src/controllers/file.controller.ts
+++ b/sci-log-db/src/controllers/file.controller.ts
@@ -39,7 +39,7 @@ class MissingFileError extends Error {
 }
 
 @authenticate('jwt')
-@authorize({allowedRoles: ['customer'], voters: [basicAuthorization]})
+@authorize({allowedRoles: ['any-authenticated-user'], voters: [basicAuthorization]})
 export class FileController {
   constructor(
     @inject(SecurityBindings.USER) private user: UserProfile,

--- a/sci-log-db/src/controllers/image.controller.ts
+++ b/sci-log-db/src/controllers/image.controller.ts
@@ -26,7 +26,7 @@ import { SecurityBindings, UserProfile } from '@loopback/security';
 import {inject} from '@loopback/core';
 
 @authenticate('jwt')
-@authorize({ allowedRoles: ['customer'], voters: [basicAuthorization] })
+@authorize({ allowedRoles: ['any-authenticated-user'], voters: [basicAuthorization] })
 export class ImageController {
   constructor(
     @inject(SecurityBindings.USER) private user: UserProfile,

--- a/sci-log-db/src/controllers/job.controller.ts
+++ b/sci-log-db/src/controllers/job.controller.ts
@@ -30,7 +30,7 @@ import { SecurityBindings, UserProfile } from '@loopback/security';
 import {inject} from '@loopback/core';
 
 @authenticate('jwt')
-@authorize({ allowedRoles: ['customer'], voters: [basicAuthorization] })
+@authorize({ allowedRoles: ['any-authenticated-user'], voters: [basicAuthorization] })
 export class JobController {
   constructor(
     @inject(SecurityBindings.USER) private user: UserProfile,

--- a/sci-log-db/src/controllers/logbook.controller.ts
+++ b/sci-log-db/src/controllers/logbook.controller.ts
@@ -10,7 +10,7 @@ import {basicAuthorization} from '../services/basic.authorizor';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 
 @authenticate('jwt')
-@authorize({allowedRoles: ['customer'], voters: [basicAuthorization]})
+@authorize({allowedRoles: ['any-authenticated-user'], voters: [basicAuthorization]})
 export class LogbookController {
   constructor(
     @inject(SecurityBindings.USER) private user: UserProfile,

--- a/sci-log-db/src/controllers/paragraph.controller.ts
+++ b/sci-log-db/src/controllers/paragraph.controller.ts
@@ -27,7 +27,7 @@ import { SecurityBindings, UserProfile } from '@loopback/security';
 import {inject} from '@loopback/core';
 
 @authenticate('jwt')
-@authorize({ allowedRoles: ['customer'], voters: [basicAuthorization] })
+@authorize({ allowedRoles: ['any-authenticated-user'], voters: [basicAuthorization] })
 export class ParagraphController {
   constructor(
     @inject(SecurityBindings.USER) private user: UserProfile,

--- a/sci-log-db/src/controllers/task.controller.ts
+++ b/sci-log-db/src/controllers/task.controller.ts
@@ -31,7 +31,7 @@ import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 import {BasesnippetController} from './basesnippet.controller';
 
 @authenticate('jwt')
-@authorize({allowedRoles: ['customer'], voters: [basicAuthorization]})
+@authorize({allowedRoles: ['any-authenticated-user'], voters: [basicAuthorization]})
 export class TaskController {
   constructor(
     @inject(SecurityBindings.USER) private user: UserProfile,

--- a/sci-log-db/src/controllers/task.controller.ts
+++ b/sci-log-db/src/controllers/task.controller.ts
@@ -1,5 +1,6 @@
-import { authenticate } from '@loopback/authentication';
-import { authorize } from '@loopback/authorization';
+import {authenticate} from '@loopback/authentication';
+import {authorize} from '@loopback/authorization';
+import {inject} from '@loopback/core';
 import {
   Count,
   CountSchema,
@@ -22,15 +23,14 @@ import {
 
   requestBody
 } from '@loopback/rest';
-import { Task } from '../models';
-import { TaskRepository } from '../repositories';
-import { basicAuthorization } from '../services/basic.authorizor';
-import { OPERATION_SECURITY_SPEC } from '../utils/security-spec';
-import { SecurityBindings, UserProfile } from '@loopback/security';
-import {inject} from '@loopback/core';
+import {SecurityBindings, UserProfile} from '@loopback/security';
+import {Task} from '../models';
+import {TaskRepository} from '../repositories';
+import {basicAuthorization} from '../services/basic.authorizor';
+import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 
 @authenticate('jwt')
-@authorize({ allowedRoles: ['customer'], voters: [basicAuthorization] })
+@authorize({allowedRoles: ['customer'], voters: [basicAuthorization]})
 export class TaskController {
   constructor(
     @inject(SecurityBindings.USER) private user: UserProfile,
@@ -43,7 +43,7 @@ export class TaskController {
     responses: {
       '200': {
         description: 'Task model instance',
-        content: { 'application/json': { schema: getModelSchemaRef(Task) } },
+        content: {'application/json': {schema: getModelSchemaRef(Task)}},
       },
     },
   })
@@ -60,7 +60,7 @@ export class TaskController {
     })
     task: Omit<Task, 'id'>,
   ): Promise<Task> {
-    return this.taskRepository.create(task, { currentUser: this.user });
+    return this.taskRepository.create(task, {currentUser: this.user});
   }
 
   @get('/tasks/count', {
@@ -68,14 +68,14 @@ export class TaskController {
     responses: {
       '200': {
         description: 'Task model count',
-        content: { 'application/json': { schema: CountSchema } },
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })
   async count(
     @param.where(Task) where?: Where<Task>,
   ): Promise<Count> {
-    return this.taskRepository.count(where, { currentUser: this.user });
+    return this.taskRepository.count(where, {currentUser: this.user});
   }
 
   @get('/tasks', {
@@ -87,7 +87,7 @@ export class TaskController {
           'application/json': {
             schema: {
               type: 'array',
-              items: getModelSchemaRef(Task, { includeRelations: true }),
+              items: getModelSchemaRef(Task, {includeRelations: true}),
             },
           },
         },
@@ -97,7 +97,7 @@ export class TaskController {
   async find(
     @param.filter(Task) filter?: Filter<Task>,
   ): Promise<Task[]> {
-    return this.taskRepository.find(filter, { currentUser: this.user });
+    return this.taskRepository.find(filter, {currentUser: this.user});
   }
 
   @patch('/tasks', {
@@ -105,7 +105,7 @@ export class TaskController {
     responses: {
       '200': {
         description: 'Task PATCH success count',
-        content: { 'application/json': { schema: CountSchema } },
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })
@@ -113,14 +113,14 @@ export class TaskController {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(Task, { partial: true }),
+          schema: getModelSchemaRef(Task, {partial: true}),
         },
       },
     })
     task: Task,
     @param.where(Task) where?: Where<Task>,
   ): Promise<Count> {
-    return this.taskRepository.updateAll(task, where, { currentUser: this.user });
+    return this.taskRepository.updateAll(task, where, {currentUser: this.user});
   }
 
   @get('/tasks/{id}', {
@@ -130,7 +130,7 @@ export class TaskController {
         description: 'Task model instance',
         content: {
           'application/json': {
-            schema: getModelSchemaRef(Task, { includeRelations: true }),
+            schema: getModelSchemaRef(Task, {includeRelations: true}),
           },
         },
       },
@@ -138,9 +138,9 @@ export class TaskController {
   })
   async findById(
     @param.path.string('id') id: string,
-    @param.filter(Task, { exclude: 'where' }) filter?: FilterExcludingWhere<Task>
+    @param.filter(Task, {exclude: 'where'}) filter?: FilterExcludingWhere<Task>
   ): Promise<Task> {
-    return this.taskRepository.findById(id, filter, { currentUser: this.user });
+    return this.taskRepository.findById(id, filter, {currentUser: this.user});
   }
 
   @patch('/tasks/{id}', {
@@ -156,13 +156,13 @@ export class TaskController {
     @requestBody({
       content: {
         'application/json': {
-          schema: getModelSchemaRef(Task, { partial: true }),
+          schema: getModelSchemaRef(Task, {partial: true}),
         },
       },
     })
     task: Task,
   ): Promise<void> {
-    await this.taskRepository.updateById(id, task, { currentUser: this.user });
+    await this.taskRepository.updateById(id, task, {currentUser: this.user});
   }
 
   @put('/task/{id}', {
@@ -177,7 +177,7 @@ export class TaskController {
     @param.path.string('id') id: string,
     @requestBody() task: Task,
   ): Promise<void> {
-    await this.taskRepository.replaceById(id, task, { currentUser: this.user });
+    await this.taskRepository.replaceById(id, task, {currentUser: this.user});
   }
 
   @del('/tasks/{id}', {
@@ -188,7 +188,21 @@ export class TaskController {
       },
     },
   })
+  // async deleteById(@param.path.string('id') id: string): Promise<void> {
+  //   await this.taskRepository.deleteById(id, { currentUser: this.user });
+  // }
   async deleteById(@param.path.string('id') id: string): Promise<void> {
-    await this.taskRepository.deleteById(id, { currentUser: this.user });
+    // Two steps:
+    // 1. set snippet to 'deleted=true'
+    // 2. inside websocket and after informing the clients, replace the parentId or delete the snippet
+    // let snippet = await this.taskRepository.findById(id, {}, {currentUser: this.user});
+    // if (snippet?.versionable) {
+    //   if (snippet?.parentId) {
+    //     let parent = await this.taskRepository.findById(snippet.parentId, {}, {currentUser: this.user});
+    //     let parentHistory = await this.getHistorySnippet(parent);
+    //     console.log(parentHistory);
+    //   }
+    // }
+    await this.taskRepository.updateById(id, {deleted: true}, {currentUser: this.user});
   }
 }

--- a/sci-log-db/src/controllers/user-preference.controller.ts
+++ b/sci-log-db/src/controllers/user-preference.controller.ts
@@ -23,7 +23,7 @@ import {authorize} from '@loopback/authorization';
 import {basicAuthorization} from '../services/basic.authorizor';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 @authenticate('jwt')
-@authorize({allowedRoles: ['customer'], voters: [basicAuthorization]})
+@authorize({allowedRoles: ['any-authenticated-user'], voters: [basicAuthorization]})
 
 export class UserPreferenceController {
   constructor(

--- a/sci-log-db/src/controllers/user.controller.ts
+++ b/sci-log-db/src/controllers/user.controller.ts
@@ -82,8 +82,8 @@ export class UserController {
     })
     newUserRequest: NewUserRequest,
   ): Promise<User> {
-    // All new users have the "customer" role by default
-    newUserRequest.roles = ['customer'];
+    // All new users have the "any-authenticated-user" role by default
+    newUserRequest.roles = ['any-authenticated-user'];
     // ensure a valid email value and password value
     validateCredentials({principal: newUserRequest.email, password: newUserRequest.password });
 
@@ -131,7 +131,7 @@ export class UserController {
   })
   @authenticate('jwt')
   @authorize({
-    allowedRoles: ['admin', 'customer'],
+    allowedRoles: ['admin', 'any-authenticated-user'],
     voters: [basicAuthorization],
   })
   async set(
@@ -169,7 +169,7 @@ export class UserController {
   })
   @authenticate('jwt')
   @authorize({
-    allowedRoles: ['admin', 'support', 'customer'],
+    allowedRoles: ['admin', 'support', 'any-authenticated-user'],
     voters: [basicAuthorization],
   })
   async findById(@param.path.string('userId') userId: string): Promise<User> {

--- a/sci-log-db/src/repositories/autoadd.repository.base.ts
+++ b/sci-log-db/src/repositories/autoadd.repository.base.ts
@@ -54,7 +54,7 @@ export class AutoAddRepository<
             if (ctx.data) {
                 // console.error("PATCH case")
                 ctx.data.updatedAt = new Date();
-                ctx.data.updatedBy = currentUser?.email ?? 'unknown user';
+                ctx.data.updatedBy = currentUser?.email ?? 'unknown@domain.org';
             } else {
                 if (ctx.isNewInstance) {
                     // POST case
@@ -63,14 +63,14 @@ export class AutoAddRepository<
                 // only admin may override createdAt/updateAt etc fields
                     if (currentUser.roles.includes('admin')){
                        ctx.instance.createdAt = ctx.instance.createdAt ?? new Date();                 
-                       ctx.instance.createdBy = ctx.instance.createdBy ?? currentUser?.email ?? 'unknown user';
+                       ctx.instance.createdBy = ctx.instance.createdBy ?? currentUser?.email ?? 'unknown@domain.org';
                        ctx.instance.updatedAt = ctx.instance.updatedAt ?? new Date();                 
-                       ctx.instance.updatedBy = ctx.instance.updatedBy ?? currentUser?.email ?? 'unknown user';
+                       ctx.instance.updatedBy = ctx.instance.updatedBy ?? currentUser?.email ?? 'unknown@domain.org';
                     } else {
                        ctx.instance.createdAt = new  Date();
-                       ctx.instance.createdBy = currentUser?.email ?? 'unknown user';
+                       ctx.instance.createdBy = currentUser?.email ?? 'unknown@domain.org';
                        ctx.instance.updatedAt = new Date();
-                       ctx.instance.updatedBy = currentUser?.email ?? 'unknown user';
+                       ctx.instance.updatedBy = currentUser?.email ?? 'unknown@domain.org';
                     }
                     
                     if (typeof ctx.instance.expiresAt == 'undefined') {

--- a/sci-log-db/src/repositories/autoadd.repository.base.ts
+++ b/sci-log-db/src/repositories/autoadd.repository.base.ts
@@ -56,17 +56,27 @@ export class AutoAddRepository<
                 ctx.data.updatedAt = new Date();
                 ctx.data.updatedBy = currentUser?.email ?? 'unknown user';
             } else {
-
                 if (ctx.isNewInstance) {
                     // POST case
                     // console.error("POST case")
                     ctx.instance.defaultOrder = ctx.instance.defaultOrder ?? Date.now() * 1000;
-                    ctx.instance.createdAt = new Date();
-                    ctx.instance.createdBy = currentUser?.email ?? 'unknown user';
+                // only admin may override createdAt/updateAt etc fields
+                    if (currentUser.roles.includes('admin')){
+                       ctx.instance.createdAt = ctx.instance.createdAt ?? new Date();                 
+                       ctx.instance.createdBy = ctx.instance.createdBy ?? currentUser?.email ?? 'unknown user';
+                       ctx.instance.updatedAt = ctx.instance.updatedAt ?? new Date();                 
+                       ctx.instance.updatedBy = ctx.instance.updatedBy ?? currentUser?.email ?? 'unknown user';
+                    } else {
+                       ctx.instance.createdAt = new  Date();
+                       ctx.instance.createdBy = currentUser?.email ?? 'unknown user';
+                       ctx.instance.updatedAt = new Date();
+                       ctx.instance.updatedBy = currentUser?.email ?? 'unknown user';
+                    }
+                    
                     if (typeof ctx.instance.expiresAt == 'undefined') {
-                        // default expiration time is 3 days
-                        ctx.instance.expiresAt = new Date()
-                        ctx.instance.expiresAt.setDate(ctx.instance.expiresAt.getDate() + 3);
+                    // default expiration time is 3 days
+                       ctx.instance.expiresAt = new Date()
+                       ctx.instance.expiresAt.setDate(ctx.instance.expiresAt.getDate() + 3);
                     }
                 } else {
                     // PUT case
@@ -74,9 +84,7 @@ export class AutoAddRepository<
                     // TODO restore auto generated fields, which would otherwise be lost
                     // ctx.instance.unsetAttribute('id')
                 }
-                // POST and PUT case
-                ctx.instance.updatedAt = new Date();
-                ctx.instance.updatedBy = currentUser?.email ?? 'unknown user';
+
             }
             //console.error("going to save:" + JSON.stringify(ctx, null, 3))
 

--- a/sci-log-db/src/services/export-snippets.service.ts
+++ b/sci-log-db/src/services/export-snippets.service.ts
@@ -1,6 +1,9 @@
-import {bind, BindingScope, ContextTags} from '@loopback/core';
+import {bind, BindingScope, ContextTags, inject} from '@loopback/core';
 import {EXPORT_SERVICE} from '../keys';
+import {FileRepository} from '../repositories/file.repository';
+import {UserProfile} from '@loopback/security';
 
+const Mongo = require('mongodb');
 
 interface LateXTag {
   header: string;
@@ -21,52 +24,47 @@ export class ExportService {
   _fileCounter: number = 0;
   updateFileCounter: boolean = true;
   texFile: string;
-  texPath: string;
-  pdfOnly: boolean;
+  exportDir: string;
+
   imagePath: string;
   fs: any;
-  jobId: string;
-  imagePathLaTeX: string;
-  basePath: string;
+  user: UserProfile;
 
+  constructor(
+    @inject('repositories.FileRepository')
+    private filerepository: FileRepository
+  ) {
+  }
 
-  constructor() {}
-
-  prepareLateXSourceFile(snippets: any, jobId: string, pdfOnly: boolean, basePath: string): Promise<string> {
+  prepareLateXSourceFile(snippets: any, exportDir: string, user: UserProfile): Promise<string> {
     return new Promise<string>(async (resolve, reject) => {
       this.fs = require('fs')
-      this.pdfOnly = pdfOnly;
-      this.jobId = jobId;
-      this.basePath = basePath;
-      this.imagePath = this.pdfOnly ? this.basePath : this.basePath + jobId + "/images/";
-      this.imagePathLaTeX = this.pdfOnly ? "../" : "./images/";
-      if (!this.pdfOnly) {
-        this.fs.mkdirSync(this.imagePath);
-      }
+      this.exportDir = exportDir;
+      this.user = user;
+      this.imagePath = this.exportDir + "/images/";
+      this.fs.mkdirSync(this.imagePath);
 
-      this.texPath = this.basePath + jobId;
-      this.texFile = this.basePath + jobId + '/export.tex';
+
+      this.exportDir = this.exportDir;
+      this.texFile = this.exportDir + '/export.tex';
       var fileExport = this.fs.createWriteStream(this.texFile, {
         flags: 'w' // 'a' means appending (old data will be preserved)
       })
-      // const html2Latex = require('html-to-latex');
-
 
       let src = "";
       fileExport.write(this.prepareHeader() + "\r\n");
       for (let index = 0; index < snippets.length; index++) {
         this.currentDataSnippet = snippets[index];
-
-
+        // console.log("Handling snippet index type ",index, this.currentDataSnippet.snippetType)
         // write the quotes first
         if (this.currentDataSnippet?.subsnippets) {
           for (let subIndex = 0; subIndex < snippets[index].subsnippets.length; subIndex++) {
             this.currentDataSnippet = snippets[index].subsnippets[subIndex];
             if ((this.currentDataSnippet?.textcontent) && (this.currentDataSnippet.linkType == "quote")) {
-              let latexData: string = this.translate2LaTeX(this.currentDataSnippet.textcontent);
+              let latexData: string = await this.translate2LaTeX(this.currentDataSnippet.textcontent);
 
               fileExport.write(latexData + "\r\n");
-              console.log("resetting file counter");
+              // console.log("resetting file counter");
               this.fileCounter = 0;
             }
           }
@@ -75,11 +73,11 @@ export class ExportService {
         this.currentDataSnippet = snippets[index];
         if (this.currentDataSnippet?.textcontent) {
           // console.log(this.currentDataSnippet.textcontent);
-          let latexData: string = this.translate2LaTeX(this.currentDataSnippet.textcontent);
+          let latexData: string = await this.translate2LaTeX(this.currentDataSnippet.textcontent);
           // console.log(this.currentDataSnippet.subsnippets)
           // console.log(latexData);
           fileExport.write(latexData + "\r\n");
-          console.log("resetting file counter");
+          // console.log("resetting file counter");
           this.fileCounter = 0;
         }
         // write comments
@@ -87,8 +85,7 @@ export class ExportService {
           for (let subIndex = 0; subIndex < snippets[index].subsnippets.length; subIndex++) {
             this.currentDataSnippet = snippets[index].subsnippets[subIndex];
             if ((this.currentDataSnippet?.textcontent) && (this.currentDataSnippet.linkType == "comment")) {
-              let latexData: string = this.translate2LaTeX(this.currentDataSnippet.textcontent);
-
+              let latexData: string = await this.translate2LaTeX(this.currentDataSnippet.textcontent);
               fileExport.write(latexData + "\r\n");
               // console.log("resetting file counter");
               this.fileCounter = 0;
@@ -107,7 +104,7 @@ export class ExportService {
   compilePDF(): Promise<any> {
     const exec = require('child_process').exec;
     return new Promise((resolve, reject) => {
-      exec("cd " + this.texPath + "; pdflatex -interaction=nonstopmode ./export.tex", (error: string, stdout: string, stderr: string) => {
+      exec("cd " + this.exportDir + "; pdflatex -interaction=nonstopmode ./export.tex", (error: string, stdout: string, stderr: string) => {
         if (error) {
           console.warn(error);
         }
@@ -120,12 +117,12 @@ export class ExportService {
   createZipFile(): Promise<any> {
     const exec = require('child_process').exec;
     return new Promise((resolve, reject) => {
-      exec("cd " + this.basePath + this.jobId + "; zip -r " + this.jobId + ".zip ./images/ ./export.pdf ./export.tex", (error: string, stdout: string, stderr: string) => {
+      exec("cd " + this.exportDir + "; zip -r all.zip .", (error: string, stdout: string, stderr: string) => {
         if (error) {
           console.warn(error);
         }
 
-        resolve(this.texPath + "/" + this.jobId + ".zip");
+        resolve(this.exportDir + "/all.zip");
       });
     });
   }
@@ -210,7 +207,7 @@ export class ExportService {
     return footer
   }
 
-  private translate2LaTeX(inputString: string): string {
+  private async translate2LaTeX(inputString: string): Promise<string> {
     let out: string = '';
     const jsdom = require("jsdom");
     const {JSDOM} = jsdom;
@@ -218,19 +215,19 @@ export class ExportService {
     let element = dom.window.document.querySelector("body");
     let treeObject = {};
     if ((this.currentDataSnippet.linkType == "comment") || (this.currentDataSnippet.linkType == "quote")) {
-      let tag = this.translateHTMLTags(this.currentDataSnippet.linkType);
+      let tag = await this.translateHTMLTags(this.currentDataSnippet.linkType);
       out += tag.header;
-      out += this.unpackHTML(element, treeObject);
+      out += await this.unpackHTML(element, treeObject);
       out += tag.footer;
 
     } else {
-      out += this.unpackHTML(element, treeObject);
+      out += await this.unpackHTML(element, treeObject);
     }
 
     return out;
   }
 
-  private unpackHTML(element: any, object: any): string {
+  private async unpackHTML(element: any, object: any): Promise<string> {
     var nodeList = element.childNodes;
     var content = ""
     if (nodeList != null) {
@@ -238,8 +235,8 @@ export class ExportService {
         object[element.nodeName] = []; // IMPT: empty [] array for parent node to push non-text recursivable elements (see below)
 
         for (var i = 0; i < nodeList.length; i++) {
-          console.log("nodeName", nodeList[i].className);
-          let nodeTag = this.translateHTMLTags(nodeList[i].nodeName, nodeList[i]);
+          // console.log("nodeName", nodeList[i].className);
+          let nodeTag = await this.translateHTMLTags(nodeList[i].nodeName, nodeList[i]);
           this.checkTableCounter(nodeList[i].nodeName);
           let tmpContent = "";
           if (nodeList[i].nodeType == 3) { // if child node is **final base-case** text node
@@ -249,12 +246,12 @@ export class ExportService {
             // content += tmpContent;
           } else {
             object[element.nodeName].push({}); // push {} into empty [] array where {} for recursivable elements
-            tmpContent = this.unpackHTML(nodeList[i], object[element.nodeName][object[element.nodeName].length - 1]);
+            tmpContent = await this.unpackHTML(nodeList[i], object[element.nodeName][object[element.nodeName].length - 1]);
           }
           if (nodeTag.waitUntilRead) {
             // recalculate nodeTag before appending the content
             this.updateFileCounter = false;
-            nodeTag = this.translateHTMLTags(nodeList[i].nodeName, nodeList[i]);
+            nodeTag = await this.translateHTMLTags(nodeList[i].nodeName, nodeList[i]);
             this.updateFileCounter = true;
           }
           content += nodeTag.header;
@@ -288,7 +285,7 @@ export class ExportService {
     }
   }
 
-  private translateHTMLTags(nodeName: string, node: any = null): LateXTag {
+  private async translateHTMLTags(nodeName: string, node: any = null): Promise<LateXTag> {
     let out: LateXTag = {
       header: "",
       footer: "",
@@ -327,9 +324,6 @@ export class ExportService {
 
         break;
       case "IMG":
-        // FIXME: multiple files per snippet are currently not supported
-        // console.log("line 244:", this.currentDataSnippet);
-        console.log("fileCounter:", this.fileCounter);
         // console.log(this.currentDataSnippet.files[this.fileCounter].style.width);
         let width: string;
         let currentFile = this.currentDataSnippet.files.find((file: any) => {
@@ -345,13 +339,18 @@ export class ExportService {
         }
         let fileExt: string;
         fileExt = currentFile.fileExtension.split("/")[1];
-        // console.log(fileExt);
-        let filename = currentFile.fileId + "." + fileExt;
-        if ((!this.pdfOnly) && this.updateFileCounter) {
-          // copy files into current directory
-          this.fs.copyFileSync(this.basePath + filename, this.imagePath + filename);
+
+        // translate snippet fileid to gridfs fileid from _fileid
+        let data = await this.filerepository.findById(currentFile.fileId, undefined, {currentUser: this.user})
+        let filename=data._fileId
+
+        // copy gridfs contained images to temporary export folder
+        if (this.updateFileCounter) {
+          let bucket = new Mongo.GridFSBucket(this.filerepository.dataSource.connector?.db);
+          // the file extension needs to be added to make latex happy
+          bucket.openDownloadStream(filename).pipe(this.fs.createWriteStream(this.imagePath + filename + "." + fileExt));
         }
-        out.header = "\\includegraphics[width=" + width + "\\linewidth]{" + this.imagePathLaTeX + filename + "}\r\n"
+        out.header = "\\includegraphics[width=" + width + "\\linewidth]{" + this.imagePath + filename + "." + fileExt+"}\r\n"
         if (this.updateFileCounter) {
           this.fileCounter++;
         }
@@ -425,7 +424,7 @@ export class ExportService {
         out.footer = "\\\\";
         break;
       case "A":
-        console.log(node.href);
+        // console.log(node.href);
         out.header = "\\href{" + node.href + "}{";
         out.footer = "}\r\n";
         break;

--- a/sci-log-db/src/services/ldap-user-service.ts
+++ b/sci-log-db/src/services/ldap-user-service.ts
@@ -139,7 +139,7 @@ export class LDAPUserService implements UserService<User, Credentials> {
         var ownerGroups = [...entry.memberOf].filter(isOwnerGroup).map(
           (value: string) => value.substring(3, value.indexOf(","))
         )
-        ownerGroups.push('customer')
+        ownerGroups.push('any-authenticated-user')
         // add linked pgroup to eaccounts
         if (/^e[0-9]{5}$/.test(principal)) {
           ownerGroups.push("p" + principal.substring(1))

--- a/sci-log-db/src/utils/websocket.ts
+++ b/sci-log-db/src/utils/websocket.ts
@@ -140,8 +140,8 @@ export async function startWebsocket(app: SciLogDbApplication) {
         if (change.operationType != 'delete') {
           getId.parentId(db, change.documentKey._id, (async (id: string) => {
             if (id != null) {
-              console.log("sending data to group ", id);
-              console.log("change: ", change);
+              // console.log("sending data to group ", id);
+              // console.log("change: ", change);
 
               // make sure all subscribers have the permission to read the changestream
               let doc = await collection.findOne({'_id': Mongo.ObjectId(change.documentKey._id)});

--- a/sci-log-db/src/utils/websocket.ts
+++ b/sci-log-db/src/utils/websocket.ts
@@ -161,7 +161,8 @@ export async function startWebsocket(app: SciLogDbApplication) {
               //      an update of the document is requested and the tags are
               //      set to _delete_.
               if (change.operationType == 'update') {
-                if (change.updateDescription.updatedFields.deleted) {
+                let updatedFields = change.updateDescription.updatedFields
+                if (updatedFields.deleted) {
                   console.log("delete");
                   console.log("updated doc", doc);
                   if (doc?.versionable) {

--- a/scilog/src/app/core/remote-data.service.ts
+++ b/scilog/src/app/core/remote-data.service.ts
@@ -15,8 +15,8 @@ import { Images } from '@model/images';
 import _ from 'lodash';
 import { TagsStat } from '@model/tags';
 
-interface Count{
-  "count":number;
+interface Count {
+  "count": number;
 }
 
 @Injectable({
@@ -51,14 +51,14 @@ export class RemoteDataService {
     return this.httpClient.get<T>(this.serverSettings.getServerAddress() + snippetPath, options);
   }
 
-  protected async postImage(payloadImage:Images){
+  protected async postImage(payloadImage: Images) {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
     let data = await this.postSnippet<Images>("images", JSON.stringify(payloadImage), headers).toPromise();
     return data;
   }
 
-  protected async postFilesnippet(payload:Filesnippet, file:File){
+  protected async postFilesnippet(payload: Filesnippet, file: File) {
     let formData = new FormData();
     let headersFile = new HttpHeaders();
     headersFile = headersFile.append('accept', 'application/json');
@@ -88,45 +88,45 @@ export class LogbookItemDataService extends RemoteDataService {
   }
 
 
-  static _prepareFilters(config: WidgetItemConfig, index: number=0, count: number=Infinity): Object {
+  static _prepareFilters(config: WidgetItemConfig, index: number = 0, count: number = Infinity): Object {
     let httpFilter: Object = {};
-    if (typeof config.view.order != 'undefined'){
+    if (typeof config.view.order != 'undefined') {
       httpFilter["order"] = config.view.order;
     } else {
       httpFilter["order"] = ["defaultOrder ASC"];
     }
-    
-    let whereFilter: Object[] = []; 
+
+    let whereFilter: Object[] = [];
     whereFilter.push({ "or": [{ "snippetType": "paragraph" }, { "snippetType": "image" }] });
 
     let parentIds: string[] = [];
-    if ((config.filter?.targetId) && (config.filter.targetId.length>1)){
+    if ((config.filter?.targetId) && (config.filter.targetId.length > 1)) {
       parentIds.push(config.filter.targetId);
     }
-    if (config.filter.additionalLogbooks.length > 0){
+    if (config.filter.additionalLogbooks.length > 0) {
       parentIds.push(...config.filter.additionalLogbooks);
     }
-    if (parentIds.length>0){
+    if (parentIds.length > 0) {
       let parentFilter = [];
       for (let parent of parentIds) {
-        parentFilter.push({ "parentId": {"eq": parent }});
+        parentFilter.push({ "parentId": { "eq": parent } });
       }
-      whereFilter.push({ "or" : parentFilter});
+      whereFilter.push({ "or": parentFilter });
     }
 
 
     if ((config.filter.tags) && (config.filter.tags.length > 0)) {
-      config.filter.tags.forEach(tag=>{
-        whereFilter.push({"tags": tag})
+      config.filter.tags.forEach(tag => {
+        whereFilter.push({ "tags": tag })
       })
-      
-    }
-    httpFilter["where"] = {"and": whereFilter};
 
-    if (count < Infinity){
+    }
+    httpFilter["where"] = { "and": whereFilter };
+
+    if (count < Infinity) {
       httpFilter["limit"] = count;
     }
-    if (index > 0){
+    if (index > 0) {
       httpFilter["skip"] = index;
     }
     // console.log(httpFilter);
@@ -135,7 +135,7 @@ export class LogbookItemDataService extends RemoteDataService {
     return httpFilter;
   }
 
-  static _prepareParams(config: WidgetItemConfig, index: number=0, count: number=Infinity): HttpParams {
+  static _prepareParams(config: WidgetItemConfig, index: number = 0, count: number = Infinity): HttpParams {
     let params = new HttpParams();
     params = params.set('filter', JSON.stringify(LogbookItemDataService._prepareFilters(config, index, count)));
     return params;
@@ -159,16 +159,16 @@ export class LogbookItemDataService extends RemoteDataService {
     return this.getSnippets<Blob>(imageSnippetUrl, { responseType: 'blob' }).toPromise();
   }
 
-  async getImage(id:string){
+  async getImage(id: string) {
     // first retrieve image snippet, then filesnippet and then file
     // let fileSnippet = await this.getFilesnippet(id);
     // console.log(fileSnippet)
     // let headers = new HttpHeaders();
     // headers = headers.set('Accept', 'application/json');
-    return this.getSnippets<Blob>("filesnippet/" + id + "/files", { responseType: 'blob'}).toPromise();
+    return this.getSnippets<Blob>("filesnippet/" + id + "/files", { responseType: 'blob' }).toPromise();
   }
 
-  getFilesnippet(id:string){
+  getFilesnippet(id: string) {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
     return this.getSnippets<Filesnippet>('filesnippet/' + id, { headers: headers }).toPromise();
@@ -182,7 +182,7 @@ export class LogbookItemDataService extends RemoteDataService {
     return this.deleteSnippet("basesnippets", snippetId).toPromise();
   }
 
-  getBasesnippet(id:string){
+  getBasesnippet(id: string) {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
     let httpFilter: Object = {};
@@ -191,28 +191,28 @@ export class LogbookItemDataService extends RemoteDataService {
     let params = new HttpParams();
     params = params.set('filter', JSON.stringify(httpFilter));
 
-    return this.getSnippets<Basesnippets>('basesnippets/' + id, {headers: headers, params:params}).toPromise();
+    return this.getSnippets<Basesnippets>('basesnippets/' + id, { headers: headers, params: params }).toPromise();
   }
 
-  async getCount(config:any){
+  async getCount(config: any) {
     let filter = LogbookItemDataService._prepareFilters(config);
     // let whereFilter = filter["where"];
     console.log(filter);
     let params = new HttpParams();
     params = params.set('where', JSON.stringify(filter["where"]));
     // let count:Count = await this.getSnippets<Count>('basesnippets/count', {params:params}).toPromise();
-    return this.getSnippets<Count>('basesnippets/count', {params:params}).toPromise()
+    return this.getSnippets<Count>('basesnippets/count', { params: params }).toPromise()
   }
 
-  async getIndex(id:string, config:any){
+  async getIndex(id: string, config: any) {
     let filter = LogbookItemDataService._prepareFilters(config);
     console.log(filter);
     let params = new HttpParams();
     params = params.set('filter', JSON.stringify(filter));
-    return this.getSnippets<number>('basesnippets/index=' + id, {params:params}).toPromise()
+    return this.getSnippets<number>('basesnippets/index=' + id, { params: params }).toPromise()
   }
 
-  private async _uploadImageFile(payload: ChangeStreamNotification) : Promise<ChangeStreamNotification>{
+  private async _uploadImageFile(payload: ChangeStreamNotification): Promise<ChangeStreamNotification> {
     if (payload.files) {
       console.log(payload);
       await Promise.all(payload.files.map(async file => {
@@ -224,7 +224,7 @@ export class LogbookItemDataService extends RemoteDataService {
           let dataFile = await this.postFilesnippet(filePayload, file.file);
           console.log(filePayload)
           delete file.file;
-          
+
           console.log(file);
           // imgPayload.className = file.className;
           // imgPayload.childTag = file.childTag;
@@ -273,10 +273,10 @@ export class LogbookItemDataService extends RemoteDataService {
     }
   }
 
-  exportLogbook(exportType:string, config: any, skip: number, limit: number):Promise<Blob>{
+  exportLogbook(exportType: string, config: any, skip: number, limit: number): Promise<Blob> {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json');
-    return this.getSnippets<Blob>("basesnippets/export=" + exportType + "", {headers:headers, responseType: 'blob', params:LogbookItemDataService._prepareParams(config, skip, limit)}).toPromise();
+    return this.getSnippets<Blob>("basesnippets/export=" + exportType + "", { headers: headers, responseType: 'blob', params: LogbookItemDataService._prepareParams(config, skip, limit) }).toPromise();
   }
 }
 
@@ -317,16 +317,16 @@ export class LogbookDataService extends RemoteDataService {
     return this.getSnippets<Basesnippets[]>('basesnippets', { headers: headers, params: params }).toPromise();
   }
 
-  _getLogbookInfo(id:string):Promise<Logbooks>{
+  _getLogbookInfo(id: string): Promise<Logbooks> {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.getSnippets<Logbooks>('logbooks/' + id, {headers:headers}).toPromise();
+    return this.getSnippets<Logbooks>('logbooks/' + id, { headers: headers }).toPromise();
   }
 
-  _getAvailLogbooks():Promise<Logbooks[]>{
+  _getAvailLogbooks(): Promise<Logbooks[]> {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.getSnippets<Logbooks[]>('logbooks', {headers:headers}).toPromise();
+    return this.getSnippets<Logbooks[]>('logbooks', { headers: headers }).toPromise();
   }
 
 }
@@ -336,24 +336,24 @@ export class LogbookDataService extends RemoteDataService {
 })
 export class WidgetPreferencesDataService extends RemoteDataService {
 
-  getSnippetsForLogbook(logbookId:string): Promise<Basesnippets[]>{
+  getSnippetsForLogbook(logbookId: string): Promise<Basesnippets[]> {
     let params = new HttpParams();
     let httpFilter: Object = {};
-    httpFilter["where"] = {"parentId": logbookId};
+    httpFilter["where"] = { "parentId": logbookId };
     params = params.set('filter', JSON.stringify(httpFilter));
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.getSnippets<Basesnippets[]>('basesnippets', {headers: headers, params: params}).toPromise();
+    return this.getSnippets<Basesnippets[]>('basesnippets', { headers: headers, params: params }).toPromise();
   }
 
-  getPlotSnippets(logbookId:string): Promise<Basesnippets[]>{
+  getPlotSnippets(logbookId: string): Promise<Basesnippets[]> {
     let params = new HttpParams();
     let httpFilter: Object = {};
-    httpFilter["where"] = {"parentId": logbookId, "snippetType": "plot"};
+    httpFilter["where"] = { "parentId": logbookId, "snippetType": "plot" };
     params = params.set('filter', JSON.stringify(httpFilter));
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.getSnippets<Basesnippets[]>('basesnippets', {headers: headers, params: params}).toPromise();
+    return this.getSnippets<Basesnippets[]>('basesnippets', { headers: headers, params: params }).toPromise();
   }
 }
 
@@ -361,14 +361,14 @@ export class WidgetPreferencesDataService extends RemoteDataService {
   providedIn: 'root'
 })
 export class SnippetViewerDataService extends RemoteDataService {
-  getSnippetViewerData(snippetId:string): Promise<Basesnippets[]>{
+  getSnippetViewerData(snippetId: string): Promise<Basesnippets[]> {
     let params = new HttpParams();
     let httpFilter: Object = {};
     httpFilter["where"] = { "id": snippetId };
     params = params.set('filter', JSON.stringify(httpFilter));
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.getSnippets<Basesnippets[]>('basesnippets', {headers: headers, params: params}).toPromise();
+    return this.getSnippets<Basesnippets[]>('basesnippets', { headers: headers, params: params }).toPromise();
   }
 }
 
@@ -376,14 +376,14 @@ export class SnippetViewerDataService extends RemoteDataService {
   providedIn: 'root'
 })
 export class PlotDataService extends RemoteDataService {
-  getPlotSnippets(snippetId:string): Promise<Basesnippets[]>{
+  getPlotSnippets(snippetId: string): Promise<Basesnippets[]> {
     let params = new HttpParams();
     let httpFilter: Object = {};
     httpFilter["where"] = { "id": snippetId };
     params = params.set('filter', JSON.stringify(httpFilter));
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.getSnippets<Basesnippets[]>("basesnippets", {headers:headers, params:params}).toPromise();
+    return this.getSnippets<Basesnippets[]>("basesnippets", { headers: headers, params: params }).toPromise();
   }
 }
 
@@ -391,10 +391,10 @@ export class PlotDataService extends RemoteDataService {
   providedIn: 'root'
 })
 export class AuthDataService extends RemoteDataService {
-  login(principal:string, password:string){
+  login(principal: string, password: string) {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.postSnippet<User>('users/login', {principal, password}, headers)
+    return this.postSnippet<User>('users/login', { principal, password }, headers)
   }
 }
 
@@ -404,23 +404,27 @@ export class AuthDataService extends RemoteDataService {
 })
 export class TaskDataService extends RemoteDataService {
 
-  getTasksData(id:string) : Promise<Tasks[]>{
+  getTasksData(id: string): Promise<Tasks[]> {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
     let httpFilter: Object = {};
     httpFilter["where"] = { "parentId": id };
     let params = new HttpParams();
     params = params.set('filter', JSON.stringify(httpFilter));
-    return this.getSnippets<Tasks[]>("tasks", {headers:headers, params:params}).toPromise();
+    return this.getSnippets<Tasks[]>("tasks", { headers: headers, params: params }).toPromise();
   }
 
-  addTask(task:Tasks):Promise<any>{
+  addTask(task: Tasks): Promise<any> {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
     return this.postSnippet<any>('tasks', JSON.stringify(task), headers).toPromise();
   }
 
-  patchTask(task:Object, id: string):Promise<any>{
+  patchTask(task: Object, id: string): Promise<any> {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
     return this.patchSnippet<any>('tasks', id, JSON.stringify(task), headers).toPromise();
+  }
+
+  deleteTask(id: string): Promise<any> {
+    return this.deleteSnippet('tasks', id).toPromise();
   }
 }
 
@@ -428,23 +432,23 @@ export class TaskDataService extends RemoteDataService {
   providedIn: 'root'
 })
 export class TagDataService extends RemoteDataService {
-  private isValidTag(tag:string){
-    if (tag.includes("_delete_")){
+  private isValidTag(tag: string) {
+    if (tag.includes("_delete_")) {
       return false;
     }
     return true;
   }
-  async getTags(id:string) : Promise<TagsStat[]>{
+  async getTags(id: string): Promise<TagsStat[]> {
     let httpFilter: Object = {};
     httpFilter["where"] = { "parentId": id };
-    httpFilter["fields"] = {"tags": true};
+    httpFilter["fields"] = { "tags": true };
     let params = new HttpParams();
     params = params.set('filter', JSON.stringify(httpFilter));
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
-    let data = await this.getSnippets<Basesnippets[]>("basesnippets/", {headers:headers, params:params}).toPromise();
+    let data = await this.getSnippets<Basesnippets[]>("basesnippets/", { headers: headers, params: params }).toPromise();
     let tags = _.compact(data.map(x => {
-      if ((x.tags)&&(x.tags.length>0)){
-        return x.tags.filter(tag=>{return this.isValidTag(tag)});
+      if ((x.tags) && (x.tags.length > 0)) {
+        return x.tags.filter(tag => { return this.isValidTag(tag) });
       } else {
         return null;
       }
@@ -455,23 +459,23 @@ export class TagDataService extends RemoteDataService {
     tags.forEach(snippet => {
       snippet.forEach(tag => {
         let entry = res.find(e => e.name == tag);
-        typeof entry == 'undefined' ? res.push({name: tag, count: 1}) : entry.count += 1;
+        typeof entry == 'undefined' ? res.push({ name: tag, count: 1 }) : entry.count += 1;
       })
     })
     return _.orderBy(res, ['count'], ['desc']);
-    
+
   }
-  getLastEntry(config:WidgetItemConfig){
+  getLastEntry(config: WidgetItemConfig) {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
     console.log(config);
     let _config = JSON.parse(JSON.stringify(config));
-    if (typeof _config.view.order != 'undefined'){
+    if (typeof _config.view.order != 'undefined') {
       let order = _config.view.order[0].split(" ");
       _config.view.order = order[0] + " DESC";
     } else {
       _config.view.order = ["defaultOrder DESC"];
-    }    
+    }
     console.log(_config);
     return this.getSnippets<any[]>('basesnippets', { headers: headers, params: LogbookItemDataService._prepareParams(_config, 0, 1) }).toPromise();
   }
@@ -483,22 +487,22 @@ export class TagDataService extends RemoteDataService {
 })
 export class UserPreferencesDataService extends RemoteDataService {
 
-  getUserPreferences(){
+  getUserPreferences() {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
-    return this.getSnippets<UserPreferences[]>('user-preferences', {headers:headers});
+    return this.getSnippets<UserPreferences[]>('user-preferences', { headers: headers });
   }
 
-  getUserInfo(){
+  getUserInfo() {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
-    return this.getSnippets<UserInfo>('users/me', {headers:headers}).toPromise();
+    return this.getSnippets<UserInfo>('users/me', { headers: headers }).toPromise();
   }
 
-  postUserPreferences(payload:Object):Promise<any>{
+  postUserPreferences(payload: Object): Promise<any> {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
     return this.postSnippet<any>('user-preferences', JSON.stringify(payload), headers).toPromise();
   }
 
-  deleteUserPreferences(id:string):Promise<any>{
+  deleteUserPreferences(id: string): Promise<any> {
     return this.deleteSnippet('user-preferences', id).toPromise();
   }
 
@@ -509,28 +513,28 @@ export class UserPreferencesDataService extends RemoteDataService {
 })
 export class ViewDataService extends RemoteDataService {
 
-  getViews(id:string):Promise<Views[]>{
+  getViews(id: string): Promise<Views[]> {
     let params = new HttpParams();
     let httpFilter: Object = {};
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
     httpFilter["where"] = { "parentId": id };
     params = params.set('filter', JSON.stringify(httpFilter));
-    return this.getSnippets<Views[]>("views", {headers:headers, params:params}).toPromise();
+    return this.getSnippets<Views[]>("views", { headers: headers, params: params }).toPromise();
   }
 
-  postView(payload:any):Promise<Views>{
+  postView(payload: any): Promise<Views> {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json');
     return this.postSnippet<Views>("views", JSON.stringify(payload), headers).toPromise();
   }
 
-  patchView(payload:any, id:string):Promise<Views>{
+  patchView(payload: any, id: string): Promise<Views> {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json');
     return this.patchSnippet<Views>('views', id, JSON.stringify(payload), headers).toPromise();
   }
-  
+
 }
 
 
@@ -561,5 +565,5 @@ export class SearchDataService extends RemoteDataService {
     }
 
   }
-  
+
 }

--- a/scilog/src/app/core/toolbar/toolbar.component.html
+++ b/scilog/src/app/core/toolbar/toolbar.component.html
@@ -25,7 +25,7 @@
     </button>
   </div>
   <span>
-    <span class="version-info" *ngIf="showVersionInfo" matTooltip="v0.1">
+    <span class="version-info" *ngIf="showVersionInfo" matTooltip="v0.9">
       {{ versionInfo }}
     </span>
     <button mat-icon-button *ngIf="showMenuIcon && isLogbookOpen" (click)="openSearch()">

--- a/scilog/src/app/core/toolbar/toolbar.component.ts
+++ b/scilog/src/app/core/toolbar/toolbar.component.ts
@@ -28,7 +28,7 @@ export class ToolbarComponent implements OnInit {
   isLogbookOpen = false;
   avatarHash: string = "UserHash";
   showVersionInfo = true;
-  versionInfo = 'ALPHA';
+  versionInfo = 'BETA';
   currentView: string = "";
   showSearch = false;
   config: WidgetConfig[];

--- a/scilog/src/app/logbook/core/download/download.component.ts
+++ b/scilog/src/app/logbook/core/download/download.component.ts
@@ -21,22 +21,22 @@ export class DownloadComponent implements OnInit {
     this.exportData();
   }
 
-  async exportData(){
+  async exportData() {
     // console.log(this.config)
     // this.inProgress = true;
     // console.log(exportType);
     console.log("exportData")
     let fileSnippet = await this.logbookItemDataService.getFilesnippet(this.route.snapshot.params.fileId);
-    const blob = await this.logbookItemDataService.getFile("files/" + fileSnippet.id + "." + fileSnippet.fileExtension);
+    const blob = await this.logbookItemDataService.getImage(this.route.snapshot.params.fileId);
     console.log("blob:", blob);
-    if ((typeof blob != undefined) && (blob != null)){
+    if ((typeof blob != undefined) && (blob != null)) {
       const url = window.URL.createObjectURL(blob);
-      console.log(fileSnippet);
+      // console.log(fileSnippet);
       const link = this.downloadLink.nativeElement;
       link.href = url;
       link.download = fileSnippet.id + '.' + fileSnippet.fileExtension;
       link.click();
-    
+
       window.URL.revokeObjectURL(url);
     }
 

--- a/scilog/src/app/logbook/widgets/logbook-item/logbook-item.component.spec.ts
+++ b/scilog/src/app/logbook/widgets/logbook-item/logbook-item.component.spec.ts
@@ -360,7 +360,7 @@ describe('LogbookItemComponent', () => {
     spyOn(component, "_preparePatchPayload").and.returnValue(jasmine.any(Object));
 
     let notificationMock:ChangeStreamNotification = {id: "123", parentId:"wrongID", snippetType: "image", tags:[], linkType:"paragraphs"};
-    component["logbookInfo"].logbookInfo = {ownerGroup: "p17301", accessGroups: ["customer", "slscsaxs"], isPrivate: false, tags: []}
+    component["logbookInfo"].logbookInfo = {ownerGroup: "p17301", accessGroups: ["any-authenticated-user", "slscsaxs"], isPrivate: false, tags: []}
     component.submitContent(notificationMock);
     expect(component._preparePatchPayload).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(Object));
     expect(component["logbookItemDataService"].uploadParagraph).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(String));
@@ -371,7 +371,7 @@ describe('LogbookItemComponent', () => {
     spyOn(component, "_preparePostPayload").and.returnValue(jasmine.any(Object));
 
     let notificationMock:ChangeStreamNotification= {parentId:"123546", snippetType: "image", tags:[], linkType:"paragraphs"};
-    component["logbookInfo"].logbookInfo = {ownerGroup: "p17301", accessGroups: ["customer", "slscsaxs"], isPrivate: false, tags: []}
+    component["logbookInfo"].logbookInfo = {ownerGroup: "p17301", accessGroups: ["any-authenticated-user", "slscsaxs"], isPrivate: false, tags: []}
     component.submitContent(notificationMock);
 
     expect(component._preparePostPayload).toHaveBeenCalledWith(jasmine.any(Object), jasmine.any(Object));
@@ -379,7 +379,7 @@ describe('LogbookItemComponent', () => {
   })
 
   it('should prepare payload with correct parameters', ()=>{
-    let referenceEntry = {ownerGroup: "p17301", accessGroups: ["slscsaxs", "customer"], isPrivate: false, tags: ["alignment"]}
+    let referenceEntry = {ownerGroup: "p17301", accessGroups: ["slscsaxs", "any-authenticated-user"], isPrivate: false, tags: ["alignment"]}
     let msg = {tags: ["alignment"], textcontent: "my new snippet text", files: [], isMessage: false, linkType: "paragraph"}
 
     let res = component._preparePatchPayload(referenceEntry, msg);

--- a/scilog/src/app/logbook/widgets/logbook-item/logbook-item.component.ts
+++ b/scilog/src/app/logbook/widgets/logbook-item/logbook-item.component.ts
@@ -172,7 +172,7 @@ export class LogbookItemComponent implements OnInit {
     this.subscriptions.push(this.hotkeys.addShortcut({ keys: 'control.shift.n', description: { label: 'Set focus to editor', group: "Logbook" } }).subscribe(() => {
       this.setFocusToEditor();
     }));
-    this.subscriptions.push(this.hotkeys.addShortcut({ keys: 'shift.enter', description: { label: 'Submit content', group: "Logbook" } }).subscribe(() => {
+    this.subscriptions.push(this.hotkeys.addShortcut({ keys: 'control.enter', description: { label: 'Submit content', group: "Logbook" } }).subscribe(() => {
       this.addContent();
     }));
     this.subscriptions.push(this.hotkeys.addShortcut({ keys: 'shift.alt.enter', description: { label: 'Submit message', group: "Logbook" } }).subscribe(() => {

--- a/scilog/src/assets/config-example.json
+++ b/scilog/src/assets/config-example.json
@@ -1,0 +1,7 @@
+{
+    "lbBaseURL": "http://localhost:3000/",
+    "oAuth2Endpoint": {
+        "authURL": "auth/thirdparty/keycloak",
+        "displayText": "keycloak"
+    }
+}


### PR DESCRIPTION
Bring main branch up to date with recent issue handling and feature additions:

- attachments are stored inside Mongo via the gridfs interface
- item handling for the task list widget in the logbook is debugged
- the import tools have been extended to deal with edge cases in the import data (like missing extensions). Mapping to email addresses has been automated via LDAP queries.The admin role is allowed now to override createdAt etc fields which is needed fot he import
- small improvements for the user experience
- see also https://github.com/paulscherrerinstitute/scilog/issues?q=is%3Aissue+is%3Aclosed and https://github.com/paulscherrerinstitute/scilog/commits/feature/gridfsAttachments