### PR TITLE
Avoid injecting job repo

### DIFF
--- a/sci-log-db/src/__tests__/acceptance/basesnippet.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/basesnippet.controller.acceptance.ts
@@ -380,6 +380,7 @@ describe('Basesnippet', function (this: Suite) {
         throw err;
       });
   });
+
   it('export snippet with token should return 200 and exported pdf', async () => {
     await client
       .get(`/basesnippets/export=pdf`)
@@ -588,6 +589,29 @@ describe('Basesnippet', function (this: Suite) {
       .set('Content-Type', 'application/json')
       .expect(200)
       .then(result => expect(result.body.length).to.be.eql(0))
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  it('export snippet with token and parentId should return 200 and exported pdf', async () => {
+    await client
+      .post('/basesnippets')
+      .set('Authorization', 'Bearer ' + token)
+      .set('Content-Type', 'application/json')
+      .send({...baseSnippet, parentId: baseSnippetId});
+
+    const whereParentId = {where: {parentId: baseSnippetId}};
+    await client
+      .get(`/basesnippets/export=pdf?filter=${JSON.stringify(whereParentId)}`)
+      .set('Authorization', 'Bearer ' + token)
+      .set('Content-Type', 'application/json')
+      .expect(200)
+      .then(result =>
+        expect(result.headers['content-disposition']).to.be.eql(
+          'attachment; filename="export.pdf"',
+        ),
+      )
       .catch(err => {
         throw err;
       });


### PR DESCRIPTION
Job repo in addition with default ACLs computation result in circular dependency.
This is because:

- when calling the basesnippets/export endpoint, a basesnippet repo is created
- the export method creates a job by injecting the job repo
- if the exported content has a parentId, the job creation tries to create the job default ACLs
- the defaultACLs tries to find the snippet with the parent of the created job, and for that it calls the basenippet repo

So this results in basesnippetRepo -> jobrepo -> basesnippetRepo

Using the create of basesnippet setting explicitely the snippetType avoids the circular dependency