### PR TITLE
Add eaccount mappings and its tests

### DIFF
--- a/config/be/roles.js
+++ b/config/be/roles.js
@@ -1,0 +1,10 @@
+function roles(profile) {
+  return (profile._json?.roles ?? []).reduce(
+    (previousValue, currentValue) =>
+      /^e[0-9]{5}$/.test(currentValue)
+        ? previousValue.concat([currentValue, 'p' + currentValue.substring(1)])
+        : previousValue.concat([currentValue]),
+    [],
+  );
+}
+exports.roles = roles

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -17,8 +17,10 @@ services:
     volumes:
       - ./sci-log-db:/home/node/app
       - ./config/be/oidc.json:/home/node/app/oidc.json
+      # - ./config/be/roles.js:/home/node/app/dist/authentication-strategies/roles.js
       - ./sci-log-db/functionalAccounts-example.json:/home/node/app/functionalAccounts.json
       - /home/node/app/node_modules
+      - /home/node/app/dist
     environment:
       - JWT_SECRET=jwt_secret
     command: /bin/sh -c "while true; do sleep 600; done"

--- a/sci-log-db/src/__tests__/unit/authentication-strategies.roles.unit.ts
+++ b/sci-log-db/src/__tests__/unit/authentication-strategies.roles.unit.ts
@@ -1,0 +1,69 @@
+import {expect} from '@loopback/testlab';
+import {Suite} from 'mocha';
+import {Profile} from 'passport';
+import {roles} from '../../authentication-strategies/roles';
+import {} from '../../utils/misc';
+
+describe('Authentication strategies roles', function (this: Suite) {
+  it('Should return an empty list', () => {
+    const emptyRoles = roles({} as Profile);
+    expect(emptyRoles).to.be.eql([]);
+  });
+
+  it('Should return an empty list since json is undefined', () => {
+    const profile = {} as Profile;
+    const emptyRoles = roles({...profile, _json: undefined});
+    expect(emptyRoles).to.be.eql([]);
+  });
+
+  it('Should return an empty list since roles is undefined', () => {
+    const profile = {} as Profile;
+    const emptyRoles = roles({...profile, _json: {roles: undefined}});
+    expect(emptyRoles).to.be.eql([]);
+  });
+
+  it('Should return the list of roles', () => {
+    const profile = {} as Profile;
+    const emptyRoles = roles({
+      ...profile,
+      _json: {roles: ['g12345', 'g78910']},
+    });
+    expect(emptyRoles).to.be.eql(['g12345', 'g78910']);
+  });
+
+  it('Should return the list of roles including the p-group from e group', () => {
+    const profile = {} as Profile;
+    const emptyRoles = roles({
+      ...profile,
+      _json: {roles: ['g12345', 'g78910', 'e98765']},
+    });
+    expect(emptyRoles).to.be.eql(['g12345', 'g78910', 'e98765', 'p98765']);
+  });
+
+  it('Should return the list of roles not including the p-group from e group as smaller than 5 digits', () => {
+    const profile = {} as Profile;
+    const emptyRoles = roles({
+      ...profile,
+      _json: {roles: ['g12345', 'g78910', 'e9876']},
+    });
+    expect(emptyRoles).to.be.eql(['g12345', 'g78910', 'e9876']);
+  });
+
+  it('Should return the list of roles not including the p-group from e group as not made of digits only', () => {
+    const profile = {} as Profile;
+    const emptyRoles = roles({
+      ...profile,
+      _json: {roles: ['g12345', 'g78910', 'e987a']},
+    });
+    expect(emptyRoles).to.be.eql(['g12345', 'g78910', 'e987a']);
+  });
+
+  it('Should return the list of roles not including the p-group from e group as longer than 5 digits', () => {
+    const profile = {} as Profile;
+    const emptyRoles = roles({
+      ...profile,
+      _json: {roles: ['g12345', 'g78910', 'e987654']},
+    });
+    expect(emptyRoles).to.be.eql(['g12345', 'g78910', 'e987654']);
+  });
+});

--- a/sci-log-db/src/authentication-strategies/roles.ts
+++ b/sci-log-db/src/authentication-strategies/roles.ts
@@ -1,0 +1,11 @@
+import {Profile} from 'passport';
+
+export function roles(profile: Profile & {_json?: {roles?: string[]}}) {
+  return (profile._json?.roles ?? []).reduce(
+    (previousValue: string[], currentValue: string) =>
+      /^e[0-9]{5}$/.test(currentValue)
+        ? previousValue.concat([currentValue, 'p' + currentValue.substring(1)])
+        : previousValue.concat([currentValue]),
+    [],
+  );
+}

--- a/sci-log-db/src/authentication-strategies/types.ts
+++ b/sci-log-db/src/authentication-strategies/types.ts
@@ -7,6 +7,7 @@ import {Profile} from 'passport';
 import {User} from '../models';
 import {UserProfile, securityId} from '@loopback/security';
 import {UserRepository} from '../repositories';
+import {roles} from './roles';
 
 type ProfileUser = {
   email: string;
@@ -16,11 +17,9 @@ type ProfileUser = {
   roles: string[];
 };
 
-type UserRolesProfile = Profile & {_json: {roles: string[]}};
-
 export type VerifyFunction = (
   claimIss: string,
-  profile: UserRolesProfile,
+  profile: Profile,
   idProfile: ProfileUser,
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   context: any,
@@ -46,7 +45,7 @@ export const verifyFunctionFactory = function (
 ): VerifyFunction {
   return function (
     claimIss: string,
-    profile: UserRolesProfile,
+    profile: Profile,
     idProfile: ProfileUser,
     // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     context: any,
@@ -74,7 +73,7 @@ export const verifyFunctionFactory = function (
       lastName: lastName,
       username: profile.username,
       roles: [
-        ...(profile._json.roles ?? []),
+        ...roles(profile),
         'any-authenticated-user',
         profile.emails[0].value,
       ],


### PR DESCRIPTION
even if this seems quite PSI specific, it's possible to provide any roles mapping by bind mounting the roles.js file in the dist/authentication-strategies folder in the container, in pure JS. See the [docker-compose.dev.yaml backend container](https://github.com/paulscherrerinstitute/scilog/blob/bf605f312a69564eb13adf8ceef7de9e984b8d10/docker-compose.dev.yaml#L20).