### PR TITLE
Refactor search endpoint to leverage loobpack

### DIFF
--- a/sci-log-db/src/__tests__/acceptance/basesnippet.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/basesnippet.controller.acceptance.ts
@@ -34,7 +34,7 @@ describe('Basesnippet', function (this: Suite) {
     versionable: true,
     name: 'aSearchableName',
     description: 'aSearchableDescription',
-    textcontent: 'aSearchableTextContent',
+    textcontent: '<p>aSearchableTextContent</p>',
   };
 
   before('setupApplication', async () => {
@@ -229,7 +229,9 @@ describe('Basesnippet', function (this: Suite) {
       .then(
         result => (
           expect(result.body.length).to.be.eql(1),
-          expect(result.body[0].textcontent).to.be.eql('aSearchableTextContent')
+          expect(result.body[0].textcontent).to.be.eql(
+            '<p>aSearchableTextContent</p>',
+          )
         ),
       )
       .catch(err => {
@@ -296,7 +298,8 @@ describe('Basesnippet', function (this: Suite) {
         tags: ['aSearchExcludedTag'],
         name: 'aSearchExcludedName',
         description: 'aSearchExcludedDescription',
-        textcontent: 'aSearchExcludedTextContent',
+        textcontent:
+          '<p>aSearchExcludedTextContent</p><p>&aSearchableTextContent</p>',
       })
       .expect(204);
   });

--- a/sci-log-db/src/repositories/autoadd.repository.base.ts
+++ b/sci-log-db/src/repositories/autoadd.repository.base.ts
@@ -387,7 +387,6 @@ export class AutoAddRepository<
           },
         };
         ctx.query.where = this.addACLToFilter(ctx.query.where, groupCondition);
-        console.log();
       }
       // console.log("query:", JSON.stringify(ctx.query, null, 3));
     });


### PR DESCRIPTION
Refactoring of /search to run query on db rather than parsing results. If {include: ['subsnippets']} is specified the search is performed on subsnippets as well, going in the direction of #64 . 

@wakonig , @stephan271 I have not removed the search bar when inside a logbook as to me it does not seem to have any particular issue. Please comment on that if you think otherwise.

