### PR TITLE
Refactor allowed actions using service

### DIFF
--- a/scilog/src/app/logbook/core/snippet/snippet.component.html
+++ b/scilog/src/app/logbook/core/snippet/snippet.component.html
@@ -16,11 +16,11 @@
         <mat-icon>info</mat-icon>
         <span>Info</span>
       </button>
-      <button mat-menu-item (click)="editSnippet()" [disabled]="!enableEdit? 'disabled' : null" *ngIf="showEditButtons">
+      <button mat-menu-item (click)="editSnippet()" [disabled]="!enableEdit.update" *ngIf="showEditButtons" matTooltip="{{ isActionAllowed.tooltips.update }}">
         <mat-icon>edit</mat-icon>
         <span>Edit</span>
       </button>
-      <button mat-menu-item (click)="setDashboardName()" [disabled]="!enableEdit? 'disabled' : null">
+      <button mat-menu-item (click)="setDashboardName()" [disabled]="!enableEdit.update" matTooltip="{{ isActionAllowed.tooltips.update }}">
         <mat-icon>assistant</mat-icon>
         <span>Dashboard name</span>
       </button>
@@ -33,7 +33,7 @@
         <span>Reply</span>
       </button>
       <!-- <button mat-menu-item disabled> -->
-      <button mat-menu-item (click)="deleteSnippet()" [disabled]="!enableEdit? 'disabled' : null"
+      <button mat-menu-item (click)="deleteSnippet()" [disabled]="!enableEdit.delete" matTooltip="{{ isActionAllowed.tooltips.delete }}"
         *ngIf="showEditButtons">
         <mat-icon>delete</mat-icon>
         <span>Delete</span>

--- a/scilog/src/app/logbook/core/snippet/snippet.component.spec.ts
+++ b/scilog/src/app/logbook/core/snippet/snippet.component.spec.ts
@@ -16,7 +16,6 @@ describe('SnippetComponent', () => {
   let fixture: ComponentFixture<SnippetComponent>;
   let logbookItemDataServiceSpy: any;
   let userPreferencesServiceSpy: any;
-  let isActionAllowedService: IsAllowedService;
 
   logbookItemDataServiceSpy = jasmine.createSpyObj(
     "LogbookItemDataService", 
@@ -60,7 +59,6 @@ describe('SnippetComponent', () => {
         { provide: MatDialogRef, useValue: {} },
         { provide: LogbookItemDataService, useValue: logbookItemDataServiceSpy },
         { provide: UserPreferencesService, useValue: userPreferencesServiceSpy },
-        { provide: IsAllowedService, useClass: isActionAllowedService },
       ],
       declarations: [SnippetComponent]
     })

--- a/scilog/src/app/logbook/core/snippet/snippet.component.spec.ts
+++ b/scilog/src/app/logbook/core/snippet/snippet.component.spec.ts
@@ -304,18 +304,6 @@ describe('SnippetComponent', () => {
   });
 
   [
-    {input: {v: true, isNotExpired: true}, output: true},
-    {input: {v: true, isNotExpired: false}, output: false},
-    {input: {v: false, isNotExpired: true}, output: false},
-    {input: {v: false, isNotExpired: false}, output: false},
-  ].forEach((t, i) => {
-    it(`should test commonCondition ${i}`, () => {
-      spyOn(component['isActionAllowed'], "isNotExpired").and.returnValue(t.input.isNotExpired);
-      expect(component['commonCondition'](t.input.v)).toEqual(t.output);
-    })
-  });
-
-  [
     {input: {v: true, canUpdate: true}, output: true},
     {input: {v: true, canUpdate: false}, output: false},
     {input: {v: false, canUpdate: false}, output: false},
@@ -324,7 +312,6 @@ describe('SnippetComponent', () => {
     it(`should test enableEdit ${i}`, () => {
       spyOn(component['isActionAllowed'], "canUpdate").and.returnValue(t.input.canUpdate);
       spyOn(component['isActionAllowed'], "canDelete").and.returnValue(true);
-      spyOn<any>(component, "commonCondition").and.returnValue(t.input.v);
       component.enableEdit = t.input.v;
       expect(component._enableEdit.update).toEqual(t.output);
     })

--- a/scilog/src/app/logbook/core/snippet/snippet.component.spec.ts
+++ b/scilog/src/app/logbook/core/snippet/snippet.component.spec.ts
@@ -8,8 +8,6 @@ import { of } from 'rxjs';
 import { UserPreferencesService } from '@shared/user-preferences.service';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { WidgetItemConfig } from '@model/config';
-import { IsAllowedService } from 'src/app/overview/is-allowed.service';
-
 
 describe('SnippetComponent', () => {
   let component: SnippetComponent;

--- a/scilog/src/app/logbook/core/snippet/snippet.component.ts
+++ b/scilog/src/app/logbook/core/snippet/snippet.component.ts
@@ -28,7 +28,8 @@ import { IsAllowedService } from 'src/app/overview/is-allowed.service';
       transition('highlight => default', animate('2000ms ease-out')),
       transition('default => highlight', animate('200ms ease-in'))
     ])
-  ]
+  ],
+  providers: [IsAllowedService],
 })
 export class SnippetComponent implements OnInit {
 
@@ -146,6 +147,7 @@ export class SnippetComponent implements OnInit {
       this._hideMetadata = true;
     }
     // enable edit for snippet
+    this.isActionAllowed.snippet = this.snippet;
     this.enableEdit = true;
     this._subsnippets = new BehaviorSubject(this.snippet.subsnippets);
   }
@@ -165,19 +167,13 @@ export class SnippetComponent implements OnInit {
       });
   }
 
-  public get enableEdit() {
+  public get enableEdit(): any {
     return this._enableEdit;
   }
 
-  public set enableEdit(v: boolean | {update: boolean, delete: boolean}) {
-    const commonConditions = this.commonCondition(v);
-    this._enableEdit.update = commonConditions && this.isActionAllowed.canUpdate();
-    this._enableEdit.delete = commonConditions && this.isActionAllowed.canDelete();
-  }
-
-  private commonCondition(v: boolean | { update: boolean; delete: boolean; }) {
-    this.isActionAllowed.snippet = this.snippet;
-    return v && this.isActionAllowed.isNotExpired();
+  public set enableEdit(v: boolean) {
+    this._enableEdit.update = this.isActionAllowed.canUpdate() && v;
+    this._enableEdit.delete = this.isActionAllowed.canDelete() && v;
   }
 
   ngAfterViewChecked(): void {

--- a/scilog/src/app/logbook/widgets/todos/todos.component.html
+++ b/scilog/src/app/logbook/widgets/todos/todos.component.html
@@ -10,7 +10,7 @@
  <div *ngFor="let task of tasks; let i=index" >
   <mat-card class="task-mat-card">
     <mat-card-content class="task-content">
-        <mat-checkbox (change)="toggleTaskIsDone(i)" [checked]="task.isDone" >
+        <mat-checkbox (change)="toggleTaskIsDone(i)" [checked]="task.isDone" [disabled]="!isAllowed(i)" matTooltip="{{ isActionAllowed.tooltips.update }}">
           <div >
             
           </div>
@@ -20,7 +20,7 @@
         </span>
       <span class="flexExpand"></span>
       <span>
-        <button mat-icon-button (click)="deleteTask(i)">
+        <button mat-icon-button (click)="deleteTask(i)" [disabled]="isActionAllowed.tooltips.delete" matTooltip="{{ isActionAllowed.tooltips.delete }}">
           <mat-icon>delete</mat-icon>
         </button>
       </span>

--- a/scilog/src/app/logbook/widgets/todos/todos.component.html
+++ b/scilog/src/app/logbook/widgets/todos/todos.component.html
@@ -10,7 +10,7 @@
  <div *ngFor="let task of tasks; let i=index" >
   <mat-card class="task-mat-card">
     <mat-card-content class="task-content">
-        <mat-checkbox (change)="toggleTaskIsDone(i)" [checked]="task.isDone" [disabled]="!isAllowed(i)" matTooltip="{{ isActionAllowed.tooltips.update }}">
+        <mat-checkbox (change)="toggleTaskIsDone(i)" [checked]="task.isDone">
           <div >
             
           </div>
@@ -20,7 +20,7 @@
         </span>
       <span class="flexExpand"></span>
       <span>
-        <button mat-icon-button (click)="deleteTask(i)" [disabled]="isActionAllowed.tooltips.delete" matTooltip="{{ isActionAllowed.tooltips.delete }}">
+        <button mat-icon-button (click)="deleteTask(i)">
           <mat-icon>delete</mat-icon>
         </button>
       </span>

--- a/scilog/src/app/logbook/widgets/todos/todos.component.spec.ts
+++ b/scilog/src/app/logbook/widgets/todos/todos.component.spec.ts
@@ -8,7 +8,6 @@ import { ChangeStreamService } from '@shared/change-stream.service';
 import { AppConfigService } from 'src/app/app-config.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ViewsService } from '@shared/views.service';
-import { IsAllowedService } from 'src/app/overview/is-allowed.service';
 
 class ChangeStreamServiceMock {
   getNotification(id:string){
@@ -51,7 +50,6 @@ describe('TodosComponent', () => {
         { provide: ChangeStreamService, useClass: ChangeStreamServiceMock },
         { provide: AppConfigService, useValue: { getConfig } },
         { provide: ViewsService, useClass: ViewsServiceMock },
-        { provide: IsAllowedService, useValue: isActionAllowedServiceSpy },
       ],
       imports: [HttpClientTestingModule],
       declarations: [ TodosComponent ]
@@ -68,14 +66,6 @@ describe('TodosComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should test isAllowed', () => {
-    isActionAllowedServiceSpy.canUpdate.calls.reset();
-    isActionAllowedServiceSpy.canDelete.calls.reset();
-    component.isAllowed(0);
-    expect(isActionAllowedServiceSpy.canUpdate).toHaveBeenCalledTimes(1);
-    expect(isActionAllowedServiceSpy.canDelete).toHaveBeenCalledTimes(1);
   });
 
 });

--- a/scilog/src/app/logbook/widgets/todos/todos.component.spec.ts
+++ b/scilog/src/app/logbook/widgets/todos/todos.component.spec.ts
@@ -8,6 +8,7 @@ import { ChangeStreamService } from '@shared/change-stream.service';
 import { AppConfigService } from 'src/app/app-config.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ViewsService } from '@shared/views.service';
+import { IsAllowedService } from 'src/app/overview/is-allowed.service';
 
 class ChangeStreamServiceMock {
   getNotification(id:string){
@@ -38,9 +39,11 @@ const getConfig = () => ({});
 describe('TodosComponent', () => {
   let component: TodosComponent;
   let fixture: ComponentFixture<TodosComponent>;
-
-
+  let isActionAllowedServiceSpy
+ 
   beforeEach(waitForAsync(() => {
+    isActionAllowedServiceSpy = jasmine.createSpyObj("IsAllowedService", ["canUpdate", "canDelete"]);
+    isActionAllowedServiceSpy.tooltips = {update: '', delete: ''};  
     TestBed.configureTestingModule({
       providers:[
         {provide: LogbookInfoService, useClass: LogbookInfoMock},
@@ -48,6 +51,7 @@ describe('TodosComponent', () => {
         { provide: ChangeStreamService, useClass: ChangeStreamServiceMock },
         { provide: AppConfigService, useValue: { getConfig } },
         { provide: ViewsService, useClass: ViewsServiceMock },
+        { provide: IsAllowedService, useValue: isActionAllowedServiceSpy },
       ],
       imports: [HttpClientTestingModule],
       declarations: [ TodosComponent ]
@@ -65,4 +69,13 @@ describe('TodosComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should test isAllowed', () => {
+    isActionAllowedServiceSpy.canUpdate.calls.reset();
+    isActionAllowedServiceSpy.canDelete.calls.reset();
+    component.isAllowed(0);
+    expect(isActionAllowedServiceSpy.canUpdate).toHaveBeenCalledTimes(1);
+    expect(isActionAllowedServiceSpy.canDelete).toHaveBeenCalledTimes(1);
+  });
+
 });

--- a/scilog/src/app/logbook/widgets/todos/todos.component.ts
+++ b/scilog/src/app/logbook/widgets/todos/todos.component.ts
@@ -5,9 +5,8 @@ import { TasksService } from '@shared/tasks.service';
 import { LogbookInfoService } from '@shared/logbook-info.service';
 import { ChangeStreamService } from '@shared/change-stream.service';
 import { Subscription } from 'rxjs';
-import { Basesnippets } from '@model/basesnippets';
-import { Logbooks } from '@model/logbooks';
 import { ViewsService } from '@shared/views.service';
+import { IsAllowedService } from 'src/app/overview/is-allowed.service';
 
 @Component({
   selector: 'todos',
@@ -29,13 +28,14 @@ export class TodosComponent implements OnInit {
   constructor(private tasksService: TasksService,
     private logbookInfo: LogbookInfoService,
     private notificationService: ChangeStreamService,
-    private views: ViewsService) {
+    private views: ViewsService,
+    protected isActionAllowed: IsAllowedService) {
     console.log("constructor called")
   }
 
   ngOnInit(): void {
     // get TODOs from server
-    console.log("todo: adding subscriptions")
+    console.log("todo: adding subscriptions");
     this.subscriptions.push(this.tasksService.currentTasks.subscribe(tasks => {
       this.tasks = tasks;
       this.numTasks = this.tasksService.numTasks;
@@ -87,6 +87,12 @@ export class TodosComponent implements OnInit {
   deleteTask(id: number) {
     console.log("deleting task", id);
     this.tasksService.deleteTask(this.tasks[id].id);
+  }
+
+  isAllowed(id: number) {
+    this.isActionAllowed.snippet = this.tasks[id];
+    this.isActionAllowed.canDelete();
+    return this.isActionAllowed.canUpdate();
   }
 
   ngOnDestroy(): void {

--- a/scilog/src/app/logbook/widgets/todos/todos.component.ts
+++ b/scilog/src/app/logbook/widgets/todos/todos.component.ts
@@ -6,7 +6,6 @@ import { LogbookInfoService } from '@shared/logbook-info.service';
 import { ChangeStreamService } from '@shared/change-stream.service';
 import { Subscription } from 'rxjs';
 import { ViewsService } from '@shared/views.service';
-import { IsAllowedService } from 'src/app/overview/is-allowed.service';
 
 @Component({
   selector: 'todos',
@@ -28,8 +27,7 @@ export class TodosComponent implements OnInit {
   constructor(private tasksService: TasksService,
     private logbookInfo: LogbookInfoService,
     private notificationService: ChangeStreamService,
-    private views: ViewsService,
-    protected isActionAllowed: IsAllowedService) {
+    private views: ViewsService) {
     console.log("constructor called")
   }
 
@@ -87,12 +85,6 @@ export class TodosComponent implements OnInit {
   deleteTask(id: number) {
     console.log("deleting task", id);
     this.tasksService.deleteTask(this.tasks[id].id);
-  }
-
-  isAllowed(id: number) {
-    this.isActionAllowed.snippet = this.tasks[id];
-    this.isActionAllowed.canDelete();
-    return this.isActionAllowed.canUpdate();
   }
 
   ngOnDestroy(): void {

--- a/scilog/src/app/overview/add-logbook/add-logbook.component.html
+++ b/scilog/src/app/overview/add-logbook/add-logbook.component.html
@@ -11,14 +11,14 @@
         <div>
           <mat-form-field appearance="standard" required>
             <mat-label>Title</mat-label>
-            <input matInput placeholder="Title" [formControl]="optionsFormGroup.get('title')" matTooltip="{{ tooltips.expired }}">
+            <input matInput placeholder="Title" [formControl]="optionsFormGroup.get('title')" matTooltip="{{ isActionAllowed.tooltips.expired }}">
             <mat-error *ngIf="optionsFormGroup.get('title').hasError('required')">Please specify the title.</mat-error>
           </mat-form-field>
         </div>
         <div>
           <mat-form-field appearance="standard">
             <mat-label>Location (Beamline or Instrument)</mat-label>
-            <mat-select [formControl]="optionsFormGroup.get('location')" (selectionChange)="selectLocation($event)" matTooltip="{{ tooltips.expired }}">
+            <mat-select [formControl]="optionsFormGroup.get('location')" (selectionChange)="selectLocation($event)" matTooltip="{{ isActionAllowed.tooltips.expired }}">
               <ng-container *ngFor="let location of availLocations">
                 <mat-option [(value)]="location.id">{{ location?.location }}</mat-option>
               </ng-container>
@@ -36,7 +36,7 @@
           <mat-form-field appearance="standard" required>
             <mat-label>ownerGroup</mat-label>
             <input matInput placeholder="ownerGroup" [matAutocomplete]="autoOwnerGroup"
-              [formControl]="optionsFormGroup.get('ownerGroup')" matTooltip="{{ tooltips.ownerGroup }}">
+              [formControl]="optionsFormGroup.get('ownerGroup')" matTooltip="{{ isActionAllowed.tooltips.ownerGroup }}">
             <mat-error *ngIf="optionsFormGroup.get('ownerGroup').hasError('required')">Please specify the owner
               group.
             </mat-error>
@@ -76,12 +76,12 @@
           </mat-form-field>
         </div>
         <div>
-          <mat-slide-toggle [formControl]="optionsFormGroup.get('isPrivate')" matTooltip="{{ tooltips.expired }}">private</mat-slide-toggle>
+          <mat-slide-toggle [formControl]="optionsFormGroup.get('isPrivate')" matTooltip="{{ isActionAllowed.tooltips.expired }}">private</mat-slide-toggle>
         </div>
         <div>
           <mat-form-field appearance="standard" required>
             <mat-label>Description</mat-label>
-            <textarea matInput placeholder="Description" [formControl]="optionsFormGroup.get('description')" matTooltip="{{ tooltips.expired }}"></textarea>
+            <textarea matInput placeholder="Description" [formControl]="optionsFormGroup.get('description')" matTooltip="{{ isActionAllowed.tooltips.expired }}"></textarea>
           </mat-form-field>
         </div>
       </form>
@@ -90,7 +90,7 @@
       <img mat-card-image [src]="imageToShow" alt="" *ngIf="imageLoaded" />
       <div>
         <input style="display: none" type="file" (change)="onFileChanged($event)" #fileInput>
-        <button color="accent" aria-label="Thumbnail" class="mat-fab-bottom-right" (click)="fileInput.click()" disabled="{{ tooltips.expired }}" matTooltip="{{ tooltips.expired }}">
+        <button color="accent" aria-label="Thumbnail" class="mat-fab-bottom-right" (click)="fileInput.click()" disabled="{{ isActionAllowed.tooltips.expired }}" matTooltip="{{ isActionAllowed.tooltips.expired }}">
           {{ thumbnailText }}
         </button>
         <button color="accent" aria-label="RemoveThumbnail" class="mat-fab-bottom-right" (click)="removeThumbnail()"

--- a/scilog/src/app/overview/add-logbook/add-logbook.component.ts
+++ b/scilog/src/app/overview/add-logbook/add-logbook.component.ts
@@ -30,7 +30,8 @@ function groupCreationValidator(control: AbstractControl): { anyAuthGroup: {valu
 @Component({
   selector: 'app-add-logbook',
   templateUrl: './add-logbook.component.html',
-  styleUrls: ['./add-logbook.component.css']
+  styleUrls: ['./add-logbook.component.css'],
+  providers: [IsAllowedService]
 })
 export class AddLogbookComponent implements OnInit {
 

--- a/scilog/src/app/overview/add-logbook/add-logbook.component.ts
+++ b/scilog/src/app/overview/add-logbook/add-logbook.component.ts
@@ -11,6 +11,7 @@ import { UserPreferencesService } from '@shared/user-preferences.service';
 import { Logbooks } from '@model/logbooks';
 import { LogbookDataService, LogbookItemDataService } from '@shared/remote-data.service';
 import { SnackbarService } from 'src/app/core/snackbar.service';
+import { IsAllowedService } from '../is-allowed.service';
 
 function ownerGroupMemberValidator(groups: string[]): ValidatorFn {
   return (control: AbstractControl): { forbiddenGroup: {value: string} } | null => {
@@ -105,8 +106,6 @@ export class AddLogbookComponent implements OnInit {
   filteredAccessGroups: Observable<string[]>;
   filteredOwnerGroups: Observable<string[]>;
   accessGroupsAvail: string[] = [];
-  tooltips: {ownerGroup?: string, expired?: string} = {};
-
 
   @ViewChild('accessGroupsInput') accessGroupsInput: ElementRef<HTMLInputElement>;
   @ViewChild('auto') matAutocomplete: MatAutocomplete;
@@ -119,6 +118,7 @@ export class AddLogbookComponent implements OnInit {
     private userPreferences: UserPreferencesService,
     private logbookDataService: LogbookDataService,
     private snackBar: SnackbarService,
+    protected isActionAllowed: IsAllowedService,
     @Inject(MAT_DIALOG_DATA) data) {
     this.optionsFormGroup = fb.group({
       hideRequired: new UntypedFormControl(false),
@@ -131,8 +131,8 @@ export class AddLogbookComponent implements OnInit {
       isPrivate: new UntypedFormControl(false)
     });
     this.logbook = data;
+    this.isActionAllowed.snippet = data;
     console.log("inputData: ", data);
-
   }
 
   ngOnInit(): void {
@@ -154,39 +154,24 @@ export class AddLogbookComponent implements OnInit {
 
   private setOwnerGroupWithEditability() {
     this.setForm('ownerGroup');
-    if (!this.logbook.ownerGroup || this.isAdmin()) 
+    if (this.isActionAllowed.canChangeOwnerGroup()) 
       return
     this.getForm('ownerGroup').disable();
-    this.tooltips.ownerGroup = `Only members of '${this.logbook.adminACL}' can change the ownerGroup`;
-  }
-
-  private isAdmin() {
-    return this.accessGroupsAvail.some(group => this.logbook?.adminACL?.includes(group));
-  }
-
-  private setExpiredTooltip() {
-    const expiresAt =  new Date(this.logbook.expiresAt);
-    if (!expiresAt || expiresAt > new Date()) return;
-    const expiresString = expiresAt.toLocaleDateString(
-      'en-GB', 
-      {year: '2-digit', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'}
-    );
-    this.tooltips.expired = `Editing time (${expiresString}) has passed`;
   }
 
   private setWithEditability(toKey: string) {
     let fromKey: string;
     if (toKey === 'title') fromKey = 'name';
     this.setForm(toKey, fromKey ?? toKey);
-    if (this.tooltips.expired) this.getForm(toKey).disable();
+    if (this.isActionAllowed.tooltips.expired) this.getForm(toKey).disable();
   }
 
   setDefaults(){
     this.accessGroupsAvail = this.userPreferences.userInfo?.roles;
-    if (!this.isAdmin())
+    if (!this.isActionAllowed.isAdmin())
       this.getForm('ownerGroup').addValidators(ownerGroupMemberValidator(this.accessGroupsAvail));
     if (this.logbook) {
-      this.setExpiredTooltip();
+      this.isActionAllowed.isNotExpired();
       ['title', 'description', 'location', 'isPrivate'].map(field => this.setWithEditability(field));
       this.setOwnerGroupWithEditability();
       this.accessGroups.setValue(this.logbook.accessGroups);

--- a/scilog/src/app/overview/is-allowed.service.spec.ts
+++ b/scilog/src/app/overview/is-allowed.service.spec.ts
@@ -1,0 +1,81 @@
+import { TestBed } from "@angular/core/testing";
+import { IsAllowedService } from "./is-allowed.service";
+import { UserPreferencesService } from "../core/user-preferences.service";
+
+describe('IsAllowedService', () => {
+  let service: IsAllowedService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        IsAllowedService,
+        { provide: UserPreferencesService, useValue: {userInfo: {roles: ['roles']}} },
+      ],
+    });
+    service = TestBed.inject(IsAllowedService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+
+[
+    {input: '2200-12-12T00:00:00Z', output: undefined},
+    {input: '2023-12-12T00:00:00Z', output: jasmine.anything()}
+  ].forEach((t, i) => {
+    it(`should test isNotExpired ${i}`, () => {
+      service.snippet = {expiresAt: t.input};
+      expect(service.isNotExpired()).toEqual(!t.output? true: false);
+      expect(service.tooltips.expired).toEqual(t.output);
+      });
+  });
+
+  [
+    {input: ['roles'], output: []},
+    {input: ['someOtherRole'], output: ['someOtherRole', 'admin']}
+  ].forEach((t, i) => {
+    it(`should test otherEnabledMembers ${i}`, () => {
+      service.snippet = {adminACL: t.input};
+      expect(service['otherEnabledMembers']('admin')).toEqual(t.output);
+    });
+  });
+
+  [
+    {input: ['roles'], output: undefined},
+    {input: ['someOtherRole'], output: "Enabled for members of 'someOtherRole,admin'"}
+  ].forEach((t, i) => {
+    it(`should test isUserAllowed ${i}`, () => {
+      service.snippet = {updateACL: t.input};
+      expect(service.isUserAllowed('update')).toEqual(!t.output ? true: false);
+      expect(service.tooltips.update).toEqual(t.output);
+    });
+  });
+
+  [
+    {input: [[], []], output: undefined},
+    {input: [['someUpdate'], ['someDelete', 'admin']], output: "Enabled for members of 'someUpdate,someDelete,admin'"}
+  ].forEach((t, i) => {
+    it(`should test isAnyEditAllowed ${i}`, () => {
+      spyOn<any>(service, 'otherEnabledMembers').and.returnValues(...t.input);
+      expect(service.isAnyEditAllowed()).toEqual(!t.output ? true: false);
+      expect(service.tooltips.edit).toEqual(t.output);
+    });
+  });
+
+  [
+    {input: {expired: 'Expired', check: true}, output: 'Expired'},
+    {input: {expired: 'Expired', check: false}, output: 'Update'},
+    {input: {expired: '', check: true}, output: 'Update'},
+    {input: {expired: '', check: false}, output: 'Update'},
+  ].forEach((t, i) => {
+    it(`should test cascadeExpiration ${i}`, () => {
+      spyOn(service, 'isUserAllowed');
+      service.tooltips.expired = t.input.expired;
+      service.tooltips.update = 'Update';
+      service['cascadeExpiration']('update', t.input.check);
+      expect(service.tooltips.update).toEqual(t.output);
+    });
+  });
+  
+});

--- a/scilog/src/app/overview/is-allowed.service.spec.ts
+++ b/scilog/src/app/overview/is-allowed.service.spec.ts
@@ -21,7 +21,7 @@ describe('IsAllowedService', () => {
 
 
 [
-    {input: '2200-12-12T00:00:00Z', output: undefined},
+    {input: '2200-12-12T00:00:00Z', output: ''},
     {input: '2023-12-12T00:00:00Z', output: jasmine.anything()}
   ].forEach((t, i) => {
     it(`should test isNotExpired ${i}`, () => {
@@ -64,17 +64,21 @@ describe('IsAllowedService', () => {
   });
 
   [
-    {input: {expired: 'Expired', check: true}, output: 'Expired'},
-    {input: {expired: 'Expired', check: false}, output: 'Update'},
-    {input: {expired: '', check: true}, output: 'Update'},
+    {input: {expired: undefined, check: true}, output: 'Update'},
+    {input: {expired: undefined, check: false}, output: 'Update'},
     {input: {expired: '', check: false}, output: 'Update'},
+    {input: {expired: '', check: true}, output: 'Update'},
+    {input: {expired: 'Expired', check: false}, output: 'Expired'},
+    {input: {expired: 'Expired', check: true}, output: 'Expired'},
   ].forEach((t, i) => {
     it(`should test cascadeExpiration ${i}`, () => {
-      spyOn(service, 'isUserAllowed');
       service.tooltips.expired = t.input.expired;
+      spyOn(service, 'isNotExpired').and.returnValue(t.input.check);
+      spyOn(service, 'isUserAllowed').and.returnValue(true);
       service.tooltips.update = 'Update';
-      service['cascadeExpiration']('update', t.input.check);
+      expect(service['cascadeExpiration']('update')).toEqual(t.output === 'Expired'? false: true);
       expect(service.tooltips.update).toEqual(t.output);
+      service['cascadeExpiration']('update');
     });
   });
   

--- a/scilog/src/app/overview/is-allowed.service.ts
+++ b/scilog/src/app/overview/is-allowed.service.ts
@@ -1,0 +1,92 @@
+import { Injectable } from "@angular/core";
+import { Logbooks } from "../core/model/logbooks";
+import { UserPreferencesService } from "../core/user-preferences.service";
+import { ChangeStreamNotification } from "../logbook/core/changestreamnotification.model";
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class IsAllowedService {
+  tooltips: {
+    update?: string,
+    delete?: string,
+    ownerGroup?: string,
+    edit?: string,
+    expired?: string,
+  } = {};
+  snippet: Logbooks | ChangeStreamNotification;
+
+  constructor(private userPreferences: UserPreferencesService){}
+
+  isNotExpired() {
+    const expiresAt =  new Date(this.snippet.expiresAt);
+    if (expiresAt > new Date()) return true
+    const expiresString = expiresAt.toLocaleDateString(
+        'en-GB', 
+        {year: '2-digit', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'}
+        );
+    this.tooltips.expired = `Editing time (${expiresString}) has passed`;
+    return false
+  }
+
+  private otherEnabledMembers(action: string): string[] {
+    const aclMembers = (this.snippet?.[`${action}ACL`] ?? []).filter(
+        (m: string) => m != 'admin').concat('admin');
+    if (this.userPreferences.userInfo?.roles.some((entry: string) =>
+      aclMembers?.includes?.(entry)
+    ))
+      return [];
+    return aclMembers;
+  }
+
+  isUserAllowed(action: string) {
+    const aclMembers = this.otherEnabledMembers(action);
+    if (aclMembers.length === 0)
+      return true;
+    this.tooltips[action] = `Enabled for members of '${aclMembers}'`;
+    return false
+  }
+
+  isAnyEditAllowed() {
+    const groups = ['update', 'delete'].reduce((previousValue, currentValue) => 
+      previousValue.concat(this.otherEnabledMembers(currentValue)),
+      []
+    )
+    if (groups.length === 0)
+      return true
+    this.tooltips.edit = `Enabled for members of '${[...new Set(groups)]}'`;
+    return false
+  }
+
+  isAdmin() {
+    return this.isMemberOf('admin');
+  }
+
+  isMemberOf(action: string) {
+    return this.otherEnabledMembers(action).length === 0;
+  }
+
+  canChangeOwnerGroup() {
+    const adminMembers = this.otherEnabledMembers('admin');
+    if (!this.snippet.ownerGroup || adminMembers.length === 0)
+      return true
+    this.tooltips.ownerGroup = `Only members of '${adminMembers}' can change the ownerGroup`;
+    return false
+  }
+
+  canUpdate(checkExpiration = true) {
+    return this.cascadeExpiration('update', checkExpiration)
+  }
+
+  private cascadeExpiration(action: string, checkExpiration: boolean) {
+    const allowed = this.isUserAllowed(action);
+    if (checkExpiration && this.tooltips.expired)
+      this.tooltips[action] = this.tooltips.expired;
+    return allowed;
+  }
+
+  canDelete(checkExpiration = true) {
+    return this.cascadeExpiration('delete', checkExpiration)
+  }
+}

--- a/scilog/src/app/overview/is-allowed.service.ts
+++ b/scilog/src/app/overview/is-allowed.service.ts
@@ -18,16 +18,17 @@ export class IsAllowedService {
   constructor(private userPreferences: UserPreferencesService){}
 
   isNotExpired() {
-    const expiresAt =  new Date(this.snippet.expiresAt);
+    const expiresAt = new Date(this.snippet.expiresAt);
     if (expiresAt > new Date()) {
       this.tooltips.expired = '';
       return true
-    } 
-    const expiresString = expiresAt.toLocaleDateString(
+    }
+    let expiresString = `(${expiresAt.toLocaleDateString(
         'en-GB', 
         {year: '2-digit', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'}
-        );
-    this.tooltips.expired = `Editing time (${expiresString}) has passed`;
+        )}) `;
+    if (expiresString === '(Invalid Date) ') expiresString = '';
+    this.tooltips.expired = `Editing time ${expiresString}has passed`;
     return false
   }
 

--- a/scilog/src/app/overview/is-allowed.service.ts
+++ b/scilog/src/app/overview/is-allowed.service.ts
@@ -4,9 +4,7 @@ import { UserPreferencesService } from "../core/user-preferences.service";
 import { ChangeStreamNotification } from "../logbook/core/changestreamnotification.model";
 
 
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable()
 export class IsAllowedService {
   tooltips: {
     update?: string,
@@ -21,7 +19,10 @@ export class IsAllowedService {
 
   isNotExpired() {
     const expiresAt =  new Date(this.snippet.expiresAt);
-    if (expiresAt > new Date()) return true
+    if (expiresAt > new Date()) {
+      this.tooltips.expired = '';
+      return true
+    } 
     const expiresString = expiresAt.toLocaleDateString(
         'en-GB', 
         {year: '2-digit', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'}
@@ -75,18 +76,20 @@ export class IsAllowedService {
     return false
   }
 
-  canUpdate(checkExpiration = true) {
-    return this.cascadeExpiration('update', checkExpiration)
+  canUpdate() {
+    return this.cascadeExpiration('update')
   }
 
-  private cascadeExpiration(action: string, checkExpiration: boolean) {
-    const allowed = this.isUserAllowed(action);
-    if (checkExpiration && this.tooltips.expired)
-      this.tooltips[action] = this.tooltips.expired;
-    return allowed;
+  private cascadeExpiration(action: string) {
+    if (this.tooltips.expired === undefined && this.isNotExpired())
+      return this.isUserAllowed(action);
+    else if (!this.tooltips.expired)
+      return this.isUserAllowed(action);
+    this.tooltips[action] = this.tooltips.expired;
+    return false;
   }
 
-  canDelete(checkExpiration = true) {
-    return this.cascadeExpiration('delete', checkExpiration)
+  canDelete() {
+    return this.cascadeExpiration('delete')
   }
 }

--- a/scilog/src/app/overview/logbook-cover/logbook-cover.component.html
+++ b/scilog/src/app/overview/logbook-cover/logbook-cover.component.html
@@ -3,18 +3,18 @@
     <mat-card-title #cardHeader style="font-size: 18px;">{{ logbook?.name }}</mat-card-title>
     <mat-card-subtitle>{{ logbook?.ownerGroup }}</mat-card-subtitle>
     <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="Example icon-button with a menu"
-      class="mat-fab-top-right"  [disabled]="tooltips.edit" matTooltip="{{ tooltips.edit }}">
+      class="mat-fab-top-right"  [disabled]="isActionAllowed.tooltips.edit" matTooltip="{{ isActionAllowed.tooltips.edit }}">
       <mat-icon>more_vert</mat-icon>
     </button>
     <mat-menu #menu="matMenu">
-      <span [matTooltip]="tooltips.update">
-        <button mat-menu-item (click)="editLogbook()" [disabled]="tooltips.update">
+      <span [matTooltip]="isActionAllowed.tooltips.update">
+        <button mat-menu-item (click)="editLogbook()" [disabled]="isActionAllowed.tooltips.update">
           <mat-icon>edit</mat-icon>
           <span>Edit</span>
         </button>
       </span>
-      <span [matTooltip]="tooltips.delete">
-        <button mat-menu-item (click)="deleteLogbook()" [disabled]="tooltips.delete">
+      <span [matTooltip]="isActionAllowed.tooltips.delete">
+        <button mat-menu-item (click)="deleteLogbook()" [disabled]="isActionAllowed.tooltips.delete">
           <mat-icon>delete</mat-icon>
           <span>Delete</span>
         </button>

--- a/scilog/src/app/overview/logbook-cover/logbook-cover.component.spec.ts
+++ b/scilog/src/app/overview/logbook-cover/logbook-cover.component.spec.ts
@@ -73,24 +73,10 @@ describe('LogbookWidgetComponent', () => {
   });
 
 
-  [
-    {input: ['roles'], output: ['updateRole']},
-    {input: ['updateRole'], output: []},
-    {input: ['admin'], output: []}
-  ].forEach((t, i) => {
-    it(`should test enable members ${i}`, () => {
-      component['userPreferences'].userInfo.roles = t.input;
-      const groups = component['enabledMembers']('update');
-      expect(groups).toEqual(t.output);
-      if (t.output.length > 0)
-        expect(component.tooltips.update).toEqual(`Enabled for members of '${t.output.concat('admin')}'`);
-    });
+  it('should test enableActions', () => {
+    const isAnyEditAllowedSpy = spyOn(component['isActionAllowed'], 'isAnyEditAllowed');
+    component['enableActions']();
+    expect(isAnyEditAllowedSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should test enableActions', () => {
-    component['enableActions']();
-    expect(component.tooltips.update).toEqual(`Enabled for members of 'updateRole,admin'`);
-    expect(component.tooltips.delete).toEqual(`Enabled for members of 'deleteRole,admin'`);
-    expect(component.tooltips.edit).toEqual(`Enabled for members of 'updateRole,deleteRole,admin'`);
-  });
 });

--- a/scilog/src/app/overview/logbook-cover/logbook-cover.component.ts
+++ b/scilog/src/app/overview/logbook-cover/logbook-cover.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, EventEmitter, Output, Input, ViewChild, ElementRef } from '@angular/core';
-import { UserPreferencesService } from '@shared/user-preferences.service';
 import { Logbooks } from '@model/logbooks';
 import { LogbookInfoService } from '@shared/logbook-info.service';
 import { LogbookItemDataService } from '@shared/remote-data.service';
@@ -8,7 +7,8 @@ import { IsAllowedService } from '../is-allowed.service';
 @Component({
   selector: 'app-logbook-cover',
   templateUrl: './logbook-cover.component.html',
-  styleUrls: ['./logbook-cover.component.css']
+  styleUrls: ['./logbook-cover.component.css'],
+  providers: [IsAllowedService]
 })
 export class LogbookWidgetComponent implements OnInit {
 


### PR DESCRIPTION
Introduces a services to select allowed actions and checks them for "snippets" and "todos" in addition to "cover" and "logbook edit"