### PR TITLE
Firefox fitting

### DIFF
--- a/scilog/src/app/overview/logbook-cover/logbook-cover.component.css
+++ b/scilog/src/app/overview/logbook-cover/logbook-cover.component.css
@@ -2,45 +2,45 @@
 
   width: 300px;
   height: 400px;
+}
 
-  .mat-card-content {
+.mat-card-content {
     padding: 15px;
     height: 170px;
     overflow-y: scroll;
-  }
+}
 
-  .mat-card-header .mat-card-title {
-    width: 100%;
-    height: 30px;
-    display: inline-flex;
-  }
+.mat-card-header .mat-card-title {
+  width: 100%;
+  height: 30px;
+  display: inline-flex;
+}
 
-  .image-container {
-    text-align: center;
-  }
+.image-container {
+  text-align: center;
+}
 
-  .mat-fab-top-right {
-    position: absolute;
-    top: 5px;
-    right: 1px;
-    z-index: 100;
-    display: flex;
-    flex-direction: column-reverse;
-    align-items: center;
-  }
+.mat-fab-top-right {
+  position: absolute;
+  top: 5px;
+  right: 1px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+}
 
-  .mat-card-actions {
-    width: 300px;
-    align-items: center;
-    text-align: center;
-    position: absolute;
-    bottom: 15px;
-  }
+.mat-card-actions {
+  width: 300px;
+  align-items: center;
+  text-align: center;
+  position: absolute;
+  bottom: 15px;
+}
 
-  mat-divider {
-    position: absolute;
-    bottom: 50px;
-  }
+mat-divider {
+  position: absolute;
+  bottom: 50px;
 }
 
 .logbook-module img {

--- a/scilog/src/app/overview/logbook-cover/logbook-cover.component.css
+++ b/scilog/src/app/overview/logbook-cover/logbook-cover.component.css
@@ -9,7 +9,7 @@
     overflow-y: scroll;
   }
 
-  .mat-card-title {
+  .mat-card-header .mat-card-title {
     width: 100%;
     height: 30px;
     display: inline-flex;

--- a/scilog/src/app/overview/logbook-cover/logbook-cover.component.css
+++ b/scilog/src/app/overview/logbook-cover/logbook-cover.component.css
@@ -4,23 +4,23 @@
   height: 400px;
 }
 
-.mat-card-content {
+.logbook-module .mat-card-content {
     padding: 15px;
     height: 170px;
     overflow-y: scroll;
 }
 
-.mat-card-header .mat-card-title {
+.logbook-module .mat-card-header .mat-card-title {
   width: 100%;
   height: 30px;
   display: inline-flex;
 }
 
-.image-container {
+.logbook-module .image-container {
   text-align: center;
 }
 
-.mat-fab-top-right {
+.logbook-module .mat-fab-top-right {
   position: absolute;
   top: 5px;
   right: 1px;
@@ -30,7 +30,7 @@
   align-items: center;
 }
 
-.mat-card-actions {
+.logbook-module .mat-card-actions {
   width: 300px;
   align-items: center;
   text-align: center;
@@ -38,7 +38,7 @@
   bottom: 15px;
 }
 
-mat-divider {
+.logbook-module mat-divider {
   position: absolute;
   bottom: 50px;
 }
@@ -50,72 +50,69 @@ mat-divider {
 }
 
 .logbook-headline {
-
   display: flex;
+}
 
-  .mat-fab-top-right {
-    position: absolute;
-    top: 1px;
-    right: 1px;
-    z-index: 100;
-    display: flex;
-    flex-direction: column-reverse;
-    align-items: center;
-  }
+.logbook-headline .mat-fab-top-right {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+}
 
+.logbook-headline .owner {
+  margin-bottom: -1px;
+  margin-right: 10px;
+  width: 10%;
+  overflow-x: scroll;
+  min-height: 20px;
+  scrollbar-width: none;
+}
 
-  .owner {
-    margin-bottom: -1px;
-    margin-right: 10px;
-    width: 10%;
-    overflow-x: scroll;
-    min-height: 20px;
-    scrollbar-width: none;
-  }
+.logbook-headline .date {
+  font-size: small;
+  margin: 15px;
+  width: 10%;
+}
 
-  .date {
-    font-size: small;
-    margin: 15px;
-    width: 10%;
-  }
+.logbook-headline .description {
+  width: 20%;
+  overflow-x: scroll;
+  word-wrap: break-word;
+  min-height: 20px;
+  margin-bottom: 1px;
+  margin-right: 10px;
+  scrollbar-width: none;
+}
 
-  .description {
-    width: 20%;
-    overflow-x: scroll;
-    word-wrap: break-word;
-    min-height: 20px;
-    margin-bottom: 1px;
-    margin-right: 10px;
-    scrollbar-width: none;
-  }
+.logbook-headline .title {
+  width: 40%;
+  overflow-x: scroll;
+  word-wrap: break-word;
+  min-height: 20px;
+  margin-bottom: 1px;
+  margin-right: 10px;
+  scrollbar-width: none;
+}
 
-  .title {
-    width: 40%;
-    overflow-x: scroll;
-    word-wrap: break-word;
-    min-height: 20px;
-    margin-bottom: 1px;
-    margin-right: 10px;
-    scrollbar-width: none;
-  }
+.logbook-headline img {
+  max-height: 35px;
+  max-width: 35px;
+  box-shadow: 0 1px 4px 0 rgba(0, 0, 0, .2), 0 2px 8px 0 rgba(0, 0, 0, .14), 0 4px 8px -1px rgba(0, 0, 0, .12);
+}
 
-  img {
-    max-height: 35px;
-    max-width: 35px;
-    box-shadow: 0 1px 4px 0 rgba(0, 0, 0, .2), 0 2px 8px 0 rgba(0, 0, 0, .14), 0 4px 8px -1px rgba(0, 0, 0, .12);
-  }
-
-  .card-container {
-    height: 10px;
-    flex: 1 1 auto;
-    display: flex;
-    flex-direction: column;
-    align-content: flex-start;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
-    margin-right: 10px;
-    overflow-x: clip;
-  }
-
+.logbook-headline .card-container {
+  height: 10px;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-content: flex-start;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-right: 10px;
+  overflow-x: clip;
 }

--- a/scilog/src/app/overview/logbook-cover/logbook-cover.component.css
+++ b/scilog/src/app/overview/logbook-cover/logbook-cover.component.css
@@ -8,6 +8,7 @@
     padding: 15px;
     height: 170px;
     overflow-y: scroll;
+    scrollbar-width: none;
 }
 
 .logbook-module .mat-card-header .mat-card-title {

--- a/scilog/src/app/overview/logbook-cover/logbook-cover.component.css
+++ b/scilog/src/app/overview/logbook-cover/logbook-cover.component.css
@@ -19,12 +19,6 @@
     text-align: center;
   }
 
-  img {
-    max-width: 250px;
-    height: 80px;
-    box-shadow: 0 1px 4px 0 rgba(0, 0, 0, .2), 0 2px 8px 0 rgba(0, 0, 0, .14), 0 4px 8px -1px rgba(0, 0, 0, .12);
-  }
-
   .mat-fab-top-right {
     position: absolute;
     top: 5px;
@@ -47,6 +41,12 @@
     position: absolute;
     bottom: 50px;
   }
+}
+
+.logbook-module img {
+  max-width: 250px;
+  height: 80px;
+  box-shadow: 0 1px 4px 0 rgba(0, 0, 0, .2), 0 2px 8px 0 rgba(0, 0, 0, .14), 0 4px 8px -1px rgba(0, 0, 0, .12);
 }
 
 .logbook-headline {


### PR DESCRIPTION
for some very obscure reason, in old browsers, doing in css

```
.a {
 .b {}
}

```
is not the same as 
```
.a .b {}
```

do you maybe know why @wakonig 