### PR TITLE
Refactor search recursively

### DIFF
--- a/sci-log-db/src/__tests__/acceptance/file.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/file.controller.acceptance.ts
@@ -190,9 +190,9 @@ describe('File controller services', function (this: Suite) {
     const includeTags = {fields: {tags: true}, include: ['subsnippets']};
     await client
       .get(
-        `/filesnippet/search=aSearchabletag?filter=${JSON.stringify(
-          includeTags,
-        )}`,
+        `/filesnippet/search=${encodeURIComponent(
+          '#aSearchableTag',
+        )}?filter=${JSON.stringify(includeTags)}`,
       )
       .set('Authorization', 'Bearer ' + token)
       .set('Content-Type', 'application/json')

--- a/sci-log-db/src/__tests__/acceptance/location.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/location.controller.acceptance.ts
@@ -194,9 +194,9 @@ describe('Location', function (this: Suite) {
     const includeTags = {fields: {tags: true}, include: ['subsnippets']};
     await client
       .get(
-        `/locations/search=aSearchabletag?filter=${JSON.stringify(
-          includeTags,
-        )}`,
+        `/locations/search=${encodeURIComponent(
+          '#aSearchableTag',
+        )}?filter=${JSON.stringify(includeTags)}`,
       )
       .set('Authorization', 'Bearer ' + token)
       .set('Content-Type', 'application/json')

--- a/sci-log-db/src/__tests__/acceptance/logbook.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/logbook.controller.acceptance.ts
@@ -187,7 +187,9 @@ describe('Logbook', function (this: Suite) {
     const includeTags = {fields: {tags: true}, include: ['subsnippets']};
     await client
       .get(
-        `/logbooks/search=aSearchabletag?filter=${JSON.stringify(includeTags)}`,
+        `/logbooks/search=${encodeURIComponent(
+          '#aSearchableTag',
+        )}?filter=${JSON.stringify(includeTags)}`,
       )
       .set('Authorization', 'Bearer ' + token)
       .set('Content-Type', 'application/json')

--- a/sci-log-db/src/__tests__/acceptance/paragraph.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/paragraph.controller.acceptance.ts
@@ -167,9 +167,9 @@ describe('Paragraph', function (this: Suite) {
     const includeTags = {fields: {tags: true}, include: ['subsnippets']};
     await client
       .get(
-        `/paragraphs/search=aSearchabletag?filter=${JSON.stringify(
-          includeTags,
-        )}`,
+        `/paragraphs/search=${encodeURIComponent(
+          '#aSearchableTag',
+        )}?filter=${JSON.stringify(includeTags)}`,
       )
       .set('Authorization', 'Bearer ' + token)
       .set('Content-Type', 'application/json')

--- a/sci-log-db/src/__tests__/acceptance/task.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/task.controller.acceptance.ts
@@ -164,7 +164,11 @@ describe('TaskRepositorySnippet', function (this: Suite) {
   it('Search index with token should return 200 and matching body.tags', async () => {
     const includeTags = {fields: {tags: true}, include: ['subsnippets']};
     await client
-      .get(`/tasks/search=aSearchabletag?filter=${JSON.stringify(includeTags)}`)
+      .get(
+        `/tasks/search=${encodeURIComponent(
+          '#aSearchableTag',
+        )}?filter=${JSON.stringify(includeTags)}`,
+      )
       .set('Authorization', 'Bearer ' + token)
       .set('Content-Type', 'application/json')
       .expect(200)

--- a/sci-log-db/src/__tests__/unit/utils.misc.unit.ts
+++ b/sci-log-db/src/__tests__/unit/utils.misc.unit.ts
@@ -9,9 +9,95 @@ import {
   defaultSequentially,
   concatOwnerAccessGroups,
   arrayOfUniqueFrom,
+  filterEmptySubsnippets,
+  standardiseIncludes,
 } from '../../utils/misc';
 
 describe('Utils unit tests', function (this: Suite) {
+  it('Should filterEmptySubsnippets', () => {
+    const snippet = {
+      subsnippets: [
+        {
+          subsnippets: [
+            undefined,
+            {subsnippets: [1, undefined]},
+            {subsnippets: [undefined, undefined]},
+            {subsnippets: undefined},
+            {subsnippets: []},
+          ],
+        },
+      ],
+    } as Basesnippet;
+    filterEmptySubsnippets(snippet);
+    expect(snippet).to.eql({
+      subsnippets: [{subsnippets: [{subsnippets: [1]}]}],
+    });
+  });
+
+  [
+    {
+      subsnippets: [
+        {
+          subsnippets: [
+            undefined,
+            {subsnippets: [1, undefined]},
+            {subsnippets: [undefined, undefined]},
+            {subsnippets: undefined},
+            {subsnippets: []},
+          ],
+        },
+        undefined,
+      ],
+    },
+    {
+      subsnippets: [
+        {
+          subsnippets: [
+            undefined,
+            {subsnippets: [1, undefined]},
+            {subsnippets: [undefined, undefined]},
+            {subsnippets: undefined},
+            {subsnippets: []},
+          ],
+        },
+      ],
+    },
+    {
+      subsnippets: [
+        {
+          subsnippets: [
+            {subsnippets: [1, undefined]},
+            {subsnippets: [undefined, undefined]},
+            {subsnippets: undefined},
+            {subsnippets: []},
+          ],
+        },
+      ],
+    },
+    {
+      subsnippets: [{subsnippets: [{subsnippets: [1]}]}],
+    },
+  ].forEach((t, i) => {
+    it(`Should filterEmptySubsnippets with maxDept ${i}`, () => {
+      const snippet = {
+        subsnippets: [
+          {
+            subsnippets: [
+              undefined,
+              {subsnippets: [1, undefined]},
+              {subsnippets: [undefined, undefined]},
+              {subsnippets: undefined},
+              {subsnippets: []},
+            ],
+          },
+          undefined,
+        ],
+      } as Basesnippet;
+      filterEmptySubsnippets(snippet, i);
+      expect(snippet).to.eql(t);
+    });
+  });
+
   it('Should add deprecated to delete', () => {
     const withDeprecated = getModelSchemaRefWithDeprecated(Basesnippet, {
       deprecated: ['deleted'],
@@ -156,6 +242,34 @@ describe('Utils unit tests', function (this: Suite) {
   ].forEach((t, i) => {
     it(`Should test arrayOfUniqueFrom ${i}`, () => {
       expect(arrayOfUniqueFrom(...t.input)).to.be.eql(t.expected);
+    });
+  });
+
+  [
+    {
+      input: {include: ['a']},
+      expected: {include: [{relation: 'a'}]},
+    },
+    {
+      input: {include: [{relation: 'a'}]},
+      expected: {include: [{relation: 'a'}]},
+    },
+    {
+      input: {},
+      expected: {},
+    },
+    {
+      input: {include: ['a'], where: 'b'},
+      expected: {include: [{relation: 'a'}], where: 'b'},
+    },
+    {
+      input: {include: [{relation: 'a', include: ['c']}]},
+      expected: {include: [{relation: 'a', include: [{relation: 'c'}]}]},
+    },
+  ].forEach((t, i) => {
+    it(`Should test standardiseIncludes ${i}`, () => {
+      standardiseIncludes(t.input);
+      expect(t.input).to.be.eql(t.expected);
     });
   });
 });

--- a/scilog/src/app/logbook/core/search-window/search-window.component.spec.ts
+++ b/scilog/src/app/logbook/core/search-window/search-window.component.spec.ts
@@ -43,4 +43,19 @@ describe('SearchWindowComponent', () => {
     expect(prepareConfigSpy).toHaveBeenCalledTimes(1);
   }));
 
+  it('should _parseSearchString', () => {
+    component.searchString = 'someSearch';
+    expect(component['_parseSearchString']()).toEqual(
+      {
+        location: ['id'],
+        tags: [],
+        ownerGroup: "",
+        createdBy: "",
+        startDate: "",
+        endDate: "",
+      }
+    );
+    expect(component.searchString).toEqual('someSearch');
+  });
+
 });

--- a/scilog/src/app/logbook/core/search-window/search-window.component.ts
+++ b/scilog/src/app/logbook/core/search-window/search-window.component.ts
@@ -156,26 +156,11 @@ export class SearchWindowComponent implements OnInit {
       startDate: "",
       endDate: "",
     }
-    let searchValue = "";
-    let searchParts = this.searchString.split(" ");
-    searchParts.forEach(searchPart => {
-      console.log(searchPart);
-      if (searchPart.length > 0) {
-        if (searchPart.startsWith("@")) {
-          searchResult.ownerGroup = searchPart.slice(1);
-        } else if (searchPart.startsWith("#")) {
-          console.log(searchPart)
-          searchResult.tags.push(searchPart.slice(1));
-        } else {
-          searchValue += " " + searchPart;
-        }
-      }
-    })
     console.log("local search")
     searchResult.location.push(this.logbookInfo.logbookInfo.id);
-    console.log("Search value: ", searchValue);
+    console.log("Search value: ", this.searchString);
     console.log("Search config: ", searchResult)
-    this.searchDataservice.searchString = searchValue;
+    this.searchDataservice.searchString = this.searchString;
     return searchResult;
   }
 


### PR DESCRIPTION
This refactor should allow searching leveraging mongo/lb capabilities and expand the search recursively to all subsnippets levels.

For convenience the search has special chars which encode `tag` and `users`