### PR TITLE
Fix error when removing empty subsnippets

### DIFF
--- a/sci-log-db/src/__tests__/unit/utils.misc.unit.ts
+++ b/sci-log-db/src/__tests__/unit/utils.misc.unit.ts
@@ -16,78 +16,94 @@ import {
 describe('Utils unit tests', function (this: Suite) {
   it('Should filterEmptySubsnippets', () => {
     const snippet = {
+      id: '1',
       subsnippets: [
         {
+          id: '2',
           subsnippets: [
             undefined,
-            {subsnippets: [1, undefined]},
-            {subsnippets: [undefined, undefined]},
-            {subsnippets: undefined},
-            {subsnippets: []},
+            {id: '3', subsnippets: [{id: '7'}, undefined]},
+            {id: '4', subsnippets: [undefined, undefined]},
+            {id: '5', subsnippets: undefined},
+            {id: '6', subsnippets: []},
           ],
         },
       ],
     } as Basesnippet;
     filterEmptySubsnippets(snippet);
     expect(snippet).to.eql({
-      subsnippets: [{subsnippets: [{subsnippets: [1]}]}],
+      id: '1',
+      subsnippets: [
+        {id: '2', subsnippets: [{id: '3', subsnippets: [{id: '7'}]}]},
+      ],
     });
   });
 
   [
     {
+      id: '1',
       subsnippets: [
         {
+          id: '2',
           subsnippets: [
             undefined,
-            {subsnippets: [1, undefined]},
-            {subsnippets: [undefined, undefined]},
-            {subsnippets: undefined},
-            {subsnippets: []},
+            {id: '3', subsnippets: [{id: '7'}, undefined]},
+            {id: '4', subsnippets: [undefined, undefined]},
+            {id: '5', subsnippets: undefined},
+            {id: '6', subsnippets: []},
           ],
         },
         undefined,
       ],
     },
     {
+      id: '1',
       subsnippets: [
         {
+          id: '2',
           subsnippets: [
             undefined,
-            {subsnippets: [1, undefined]},
-            {subsnippets: [undefined, undefined]},
-            {subsnippets: undefined},
-            {subsnippets: []},
+            {id: '3', subsnippets: [{id: '7'}, undefined]},
+            {id: '4', subsnippets: [undefined, undefined]},
+            {id: '5', subsnippets: undefined},
+            {id: '6', subsnippets: []},
           ],
         },
       ],
     },
     {
+      id: '1',
       subsnippets: [
         {
+          id: '2',
           subsnippets: [
-            {subsnippets: [1, undefined]},
-            {subsnippets: [undefined, undefined]},
-            {subsnippets: undefined},
-            {subsnippets: []},
+            {id: '3', subsnippets: [{id: '7'}, undefined]},
+            {id: '4', subsnippets: [undefined, undefined]},
+            {id: '5', subsnippets: undefined},
+            {id: '6', subsnippets: []},
           ],
         },
       ],
     },
     {
-      subsnippets: [{subsnippets: [{subsnippets: [1]}]}],
+      id: '1',
+      subsnippets: [
+        {id: '2', subsnippets: [{id: '3', subsnippets: [{id: '7'}]}]},
+      ],
     },
   ].forEach((t, i) => {
     it(`Should filterEmptySubsnippets with maxDept ${i}`, () => {
       const snippet = {
+        id: '1',
         subsnippets: [
           {
+            id: '2',
             subsnippets: [
               undefined,
-              {subsnippets: [1, undefined]},
-              {subsnippets: [undefined, undefined]},
-              {subsnippets: undefined},
-              {subsnippets: []},
+              {id: '3', subsnippets: [{id: '7'}, undefined]},
+              {id: '4', subsnippets: [undefined, undefined]},
+              {id: '5', subsnippets: undefined},
+              {id: '6', subsnippets: []},
             ],
           },
           undefined,

--- a/sci-log-db/src/utils/misc.ts
+++ b/sci-log-db/src/utils/misc.ts
@@ -184,7 +184,6 @@ export function filterEmptySubsnippets(
   maxDepth: number | undefined = undefined,
   level = 0,
   parent?: Basesnippet,
-  subsnippetIndex = 0,
 ) {
   if (
     !Object.keys(snippet).includes('subsnippets') ||
@@ -196,11 +195,15 @@ export function filterEmptySubsnippets(
     (!snippet.subsnippets || snippet?.subsnippets?.length === 0) &&
     parent?.subsnippets
   ) {
-    parent.subsnippets[subsnippetIndex] = undefined as unknown as Basesnippet;
+    const subsnippetIndex = parent.subsnippets.findIndex(
+      sub => sub.id === snippet.id,
+    );
+    if (subsnippetIndex >= 0)
+      parent.subsnippets[subsnippetIndex] = undefined as unknown as Basesnippet;
     filterEmptySubsnippets(parent as Basesnippet, maxDepth, level - 1);
   } else
-    snippet?.subsnippets?.map((sub, i) =>
-      filterEmptySubsnippets(sub, maxDepth, level + 1, snippet, i),
+    snippet?.subsnippets?.map(sub =>
+      filterEmptySubsnippets(sub, maxDepth, level + 1, snippet),
     );
 }
 


### PR DESCRIPTION
Given that the array is mutable and that its lenght is changed recursively, the index passed during recursion would not get the value consistently. For this reason the index is lookedup from the array using the snippet ID