### PR TITLE
Add unx group recursively based on FA

### DIFF
--- a/config/be/datasource.json
+++ b/config/be/datasource.json
@@ -7,5 +7,6 @@
     "password": "",
     "database": "scilog",
     "useNewUrlParser": true,
-    "useUnifiedTopology": true
+    "useUnifiedTopology": true,
+    "allowExtendedOperators": true
 }

--- a/config/be/functionalAccounts.json
+++ b/config/be/functionalAccounts.json
@@ -1,11 +1,13 @@
-[{
+[
+  {
     "username": "scilog-admin",
     "firstName": "Admin",
     "lastName": "Scilog",
     "password": "scilog@scilog",
     "email": "scilog@scilog",
     "roles": [
-        "admin",
-        "any-authenticated-user"
+      "admin",
+      "any-authenticated-user"
     ]
-}]
+  }
+]

--- a/sci-log-db/src/__tests__/acceptance/functional-accounts.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/functional-accounts.acceptance.ts
@@ -1,0 +1,202 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Client, expect, sinon} from '@loopback/testlab';
+import {Suite} from 'mocha';
+import {SciLogDbApplication} from '../..';
+import {clearDatabase, createUserToken, setupApplication} from './test-helper';
+import {BasesnippetRepository} from '../../repositories';
+import fs from 'fs';
+import {Basesnippet, Location, Logbook, Paragraph} from '../../models';
+import {CreateFunctionalAccountsObserver} from '../../observers';
+
+class TestFunctionalAccountsApp extends SciLogDbApplication {
+  locations = ['location1', 'location2'];
+  idsLocation: Record<string, string>;
+
+  constructor() {
+    super(SciLogDbApplication);
+    this.idsLocation = {};
+  }
+
+  async createLocationSnippets(location: string) {
+    const locationId = await this.createLogbook(location, {
+      snippetType: 'location',
+      location: location,
+    });
+    const acls = await this.computeAcls();
+    const snippetId = await this.createLogbook(location, {
+      snippetType: 'logbook',
+      location: locationId,
+      ...acls,
+    });
+    await this.createLogbook(location, {
+      snippetType: 'paragraph',
+      parentId: snippetId,
+      ...acls,
+    });
+  }
+
+  private async computeAcls() {
+    const basesnippetRepo = await this.getRepository(BasesnippetRepository);
+    const acls = basesnippetRepo.acls.reduce(
+      (currentValue: Record<string, ['acl']>, previousValue: string) => (
+        (currentValue[previousValue] = ['acl']), currentValue
+      ),
+      {},
+    );
+    return acls;
+  }
+
+  private async createLogbook(
+    location: string,
+    snippetArgs: Partial<Location | Logbook | Paragraph>,
+  ) {
+    const basesnippetRepo = await this.getRepository(BasesnippetRepository);
+
+    const snippet = await basesnippetRepo.create(snippetArgs, {
+      currentUser: {roles: ['admin']},
+    });
+    this.idsLocation[snippet.id] = location;
+    return snippet.id;
+  }
+
+  async migrateSchema() {
+    for (const location of this.locations) {
+      await this.createLocationSnippets(location);
+    }
+  }
+}
+
+describe('CreateFunctionalAccountsObserver', function (this: Suite) {
+  this.timeout(5000);
+  let app: TestFunctionalAccountsApp;
+  let client: Client;
+  const filePath = './functionalAccounts.json';
+  const bkFilePath = `${filePath}.bk`;
+  let token: string;
+  const sandbox = sinon.createSandbox();
+
+  function backupFunctionalAccountsFile() {
+    if (!fs.existsSync(filePath)) return;
+    const functionalAccounts = fs.readFileSync(filePath, 'utf8');
+    fs.writeFileSync(
+      bkFilePath,
+      JSON.stringify(JSON.parse(functionalAccounts), null, 2),
+      'utf8',
+    );
+  }
+
+  function restoreFunctionalAccounts() {
+    if (!fs.existsSync(bkFilePath)) return;
+    fs.copyFileSync(bkFilePath, filePath);
+    fs.unlinkSync(bkFilePath);
+  }
+
+  function createFunctionalAccountsFile() {
+    backupFunctionalAccountsFile();
+    const functionalAccounts = [
+      {
+        username: 'account1',
+        firstName: 'account1',
+        lastName: 'account1',
+        password: 'account1@account1',
+        email: 'account1@account1',
+        roles: ['admin', 'any-authenticated-user'],
+        location: 'location1',
+      },
+      {
+        username: 'account2',
+        firstName: 'account2',
+        lastName: 'account2',
+        password: 'account2@account2',
+        email: 'account2@account2',
+        roles: ['p123', 'any-authenticated-user'],
+        unxGroup: 'unxGroup2',
+        location: 'location2',
+      },
+    ];
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify(functionalAccounts, null, 2),
+      'utf8',
+    );
+  }
+
+  before('setupApplication', async () => {
+    createFunctionalAccountsFile();
+    ({app, client} = await setupApplication<TestFunctionalAccountsApp>(
+      {databaseSeeding: true},
+      TestFunctionalAccountsApp,
+    ));
+    restoreFunctionalAccounts();
+    token = await createUserToken(app, client, ['admin']);
+  });
+
+  after(async () => {
+    await clearDatabase(app);
+    if (app != null) await app.stop();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('addAclsToExistingSnippetsFromAccount', async () => {
+    await client
+      .get('/basesnippets')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(200)
+      .then(result => {
+        result.body.forEach((snippet: Basesnippet) => {
+          if (
+            snippet.snippetType === 'location' &&
+            app.idsLocation[snippet.id] === 'location1'
+          )
+            expect(snippet.updateACL).to.eql(undefined);
+          else if (
+            snippet.snippetType === 'location' &&
+            app.idsLocation[snippet.id] === 'location2'
+          )
+            expect(snippet.updateACL).to.eql(['unxGroup2']);
+          else if (app.idsLocation[snippet.id] === 'location1') {
+            expect(snippet.createACL).to.eql(['acl']);
+            expect(snippet.readACL).to.eql(['acl']);
+            expect(snippet.shareACL).to.eql(['acl']);
+            expect(snippet.updateACL).to.eql(['acl']);
+            expect(snippet.deleteACL).to.eql(['acl']);
+            expect(snippet.adminACL).to.eql(['acl']);
+          } else if (app.idsLocation[snippet.id] === 'location2') {
+            expect(snippet.createACL).to.eql(['acl', 'unxGroup2']);
+            expect(snippet.readACL).to.eql(['acl', 'unxGroup2']);
+            expect(snippet.shareACL).to.eql(['acl', 'unxGroup2']);
+            expect(snippet.updateACL).to.eql(['acl', 'unxGroup2']);
+            expect(snippet.deleteACL).to.eql(['acl', 'unxGroup2']);
+            expect(snippet.adminACL).to.eql(['acl', 'unxGroup2']);
+          }
+        });
+      });
+  });
+
+  it('migrateUnxGroup', async () => {
+    const createFunctionalAccountsObserver: CreateFunctionalAccountsObserver =
+      await app.get('lifeCycleObservers.CreateFunctionalAccountsObserver');
+    const addAclsToExistingSnippetsFromAccountSpy = sandbox.spy(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createFunctionalAccountsObserver as any,
+      'addAclsToExistingSnippetsFromAccount',
+    );
+    await createFunctionalAccountsObserver.migrateUnxGroup();
+    expect(addAclsToExistingSnippetsFromAccountSpy.callCount).to.eql(1);
+    expect(addAclsToExistingSnippetsFromAccountSpy.args[0][0]).to.match({
+      username: 'account2',
+      firstName: 'account2',
+      lastName: 'account2',
+      email: 'account2@account2',
+      unxGroup: 'unxGroup2',
+      location: 'location2',
+    });
+  });
+});

--- a/sci-log-db/src/__tests__/acceptance/test-helper.ts
+++ b/sci-log-db/src/__tests__/acceptance/test-helper.ts
@@ -13,8 +13,8 @@ import {BasesnippetRepository, TaskRepository} from '../../repositories';
 import {FileRepository} from '../../repositories/file.repository';
 import {JobRepository} from '../../repositories/job.repository';
 
-export interface AppWithClient {
-  app: SciLogDbApplication;
+export interface AppWithClient<T> {
+  app: T;
   client: Client;
 }
 
@@ -46,16 +46,17 @@ export const oidcOptions = {
   postLogoutRedirectUri: 'aRedirectUrl',
 };
 
-export async function setupApplication(
+export async function setupApplication<T extends SciLogDbApplication>(
   options: ApplicationConfig = {},
-): Promise<AppWithClient> {
-  const app = new SciLogDbApplication({
+  appClass = SciLogDbApplication,
+): Promise<AppWithClient<T>> {
+  const app = new appClass({
     rest: givenHttpServerConfig(),
-    databaseSeeding: false,
     ...options,
-  });
+  }) as T;
   await app.boot();
   app.dataSource(testdb);
+  if (!options.dirtyDb) await clearDatabase(app);
   await app.start();
   const client = createRestAppClient(app);
   return {app, client};

--- a/sci-log-db/src/__tests__/testdb.datasource.ts
+++ b/sci-log-db/src/__tests__/testdb.datasource.ts
@@ -11,4 +11,5 @@ export const testdb: juggler.DataSource = new juggler.DataSource({
   database: 'testdb',
   useNewUrlParser: true,
   useUnifiedTopology: true,
+  allowExtendedOperators: true,
 });

--- a/sci-log-db/src/application.ts
+++ b/sci-log-db/src/application.ts
@@ -55,6 +55,7 @@ import {OIDCAuthentication} from './authentication-strategies';
 import {UserServiceBindings} from './keys';
 
 import {ExpressRequestHandlersProvider} from './express-handlers/middleware-sequence';
+import {CreateFunctionalAccountsObserver} from './observers';
 
 export {ApplicationConfig};
 
@@ -231,6 +232,10 @@ export class SciLogDbApplication extends BootMixin(
   async migrateSchema(options?: SchemaMigrationOptions): Promise<void> {
     const paragraphRepo = await this.getRepository(ParagraphRepository);
     await paragraphRepo.migrateHtmlTexcontent();
+
+    const createFunctionalAccountsObserver: CreateFunctionalAccountsObserver =
+      await this.get('lifeCycleObservers.CreateFunctionalAccountsObserver');
+    await createFunctionalAccountsObserver.migrateUnxGroup();
 
     await super.migrateSchema(options);
 

--- a/sci-log-db/src/observers/create-functional-accounts.observer.ts
+++ b/sci-log-db/src/observers/create-functional-accounts.observer.ts
@@ -1,6 +1,4 @@
 import {
-  Application,
-  CoreBindings,
   inject,
   lifeCycleObserver, // The decorator
   LifeCycleObserver,
@@ -10,6 +8,11 @@ import {PasswordHasherBindings} from '../keys';
 import {UserRepository} from '../repositories/user.repository';
 import {PasswordHasher} from '../services/hash.password.bcryptjs';
 import {arrayOfUniqueFrom} from '../utils/misc';
+import {BasesnippetRepository} from '../repositories';
+import {noUnxDescendantsQuery} from './no-unx-descendants-query';
+import {Location} from '../models';
+import {AggregationCursor, ObjectId} from 'mongodb';
+import {User} from '@loopback/authentication-jwt';
 
 /**
  * This class will be bound to the application as a `LifeCycleObserver` during
@@ -17,10 +20,12 @@ import {arrayOfUniqueFrom} from '../utils/misc';
  */
 @lifeCycleObserver('')
 export class CreateFunctionalAccountsObserver implements LifeCycleObserver {
+  batchSize = 100;
   constructor(
-    @inject(CoreBindings.APPLICATION_INSTANCE) private app: Application,
     @inject('repositories.UserRepository')
     private userRepository: UserRepository,
+    @inject('repositories.BasesnippetRepository')
+    public basesnippetRepository: BasesnippetRepository,
     @inject(PasswordHasherBindings.PASSWORD_HASHER)
     public passwordHasher: PasswordHasher,
   ) {}
@@ -53,8 +58,7 @@ export class CreateFunctionalAccountsObserver implements LifeCycleObserver {
       accounts = JSON.parse(contents);
     }
 
-    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-    accounts.forEach(async (account: any) => {
+    accounts.forEach(async (account: User) => {
       const accountExists = await this.userRepository.findOne({
         where: {email: account.email},
       });
@@ -68,6 +72,8 @@ export class CreateFunctionalAccountsObserver implements LifeCycleObserver {
           account.password,
         );
 
+        await this.addAclsToExistingSnippetsFromAccount(account);
+
         // create the new user
         const savedUser = await this.userRepository.create({
           ..._.omit(account, ['password', 'roles']),
@@ -80,6 +86,78 @@ export class CreateFunctionalAccountsObserver implements LifeCycleObserver {
           .create({password});
       }
     });
+  }
+
+  private async addAclsToDescendants(locationId: string, unxGroup: string) {
+    const descendantsQuery = noUnxDescendantsQuery(locationId, unxGroup);
+    const descendants = await this.basesnippetRepository.dataSource.connector
+      .collection('Basesnippet')
+      .aggregate(descendantsQuery);
+
+    const addToSetAclsQuery = this.computeUnxAclsQuery(unxGroup);
+    await this.updateDescendantsAcls(descendants, addToSetAclsQuery);
+  }
+
+  private async updateDescendantsAcls(
+    descendants: AggregationCursor<Record<'_id', ObjectId>>,
+    addToSetAclsQuery: Record<'$addToSet', Record<string, string>>,
+  ) {
+    let batchIds = [];
+    while (await descendants.hasNext()) {
+      const descendant = await descendants.next();
+      batchIds.push(descendant!._id);
+      const isLast = !(await descendants.hasNext());
+      if (batchIds.length === this.batchSize || isLast) {
+        await this.basesnippetRepository.updateAll(
+          addToSetAclsQuery,
+          {_id: {inq: batchIds}},
+          {currentUser: {roles: ['admin']}},
+        );
+        batchIds = [];
+      }
+      if (isLast) break;
+    }
+  }
+
+  private computeUnxAclsQuery(unxGroup: string) {
+    return this.basesnippetRepository.baseACLS.reduce(
+      (
+        currentValue: Record<'$addToSet', Record<string, string>>,
+        previousValue: string,
+      ) => {
+        currentValue.$addToSet[previousValue] = unxGroup;
+        return currentValue;
+      },
+      {$addToSet: {}},
+    );
+  }
+
+  private async addAclsToLocation(location: Location, unxGroup: string) {
+    if (location.updateACL?.includes(unxGroup)) return;
+    await this.basesnippetRepository.updateById(
+      location.id,
+      {$addToSet: {updateACL: unxGroup}},
+      {currentUser: {roles: ['admin']}},
+    );
+  }
+
+  private async addAclsToExistingSnippetsFromAccount(account: User) {
+    if (!account.unxGroup || !account.location) return;
+    const location = await this.basesnippetRepository.findOne(
+      {where: {location: account.location, snippetType: 'location'}},
+      {currentUser: {roles: ['admin']}},
+    );
+    if (!location) return;
+    await this.addAclsToLocation(location, account.unxGroup);
+    await this.addAclsToDescendants(location.id, account.unxGroup);
+  }
+
+  async migrateUnxGroup() {
+    const accounts = await this.userRepository.find({
+      where: {location: {exists: true}, unxGroup: {exists: true}},
+    });
+    for await (const account of accounts)
+      await this.addAclsToExistingSnippetsFromAccount(account);
   }
 
   /**

--- a/sci-log-db/src/observers/no-unx-descendants-query.ts
+++ b/sci-log-db/src/observers/no-unx-descendants-query.ts
@@ -1,0 +1,46 @@
+import {ObjectId} from 'mongodb';
+
+export function noUnxDescendantsQuery(locationId: string, unxGroup: string) {
+  return [
+    {
+      $match: {
+        location: new ObjectId(locationId),
+        snippetType: 'logbook',
+      },
+    },
+    {
+      $graphLookup: {
+        from: 'Basesnippet',
+        startWith: '$_id',
+        connectFromField: '_id',
+        connectToField: 'parentId',
+        as: 'descendants',
+        restrictSearchWithMatch: {
+          snippetType: {$nin: ['history', 'update']},
+          $or: [
+            {createACL: {$ne: unxGroup}},
+            {readACL: {$ne: unxGroup}},
+            {shareACL: {$ne: unxGroup}},
+            {updateACL: {$ne: unxGroup}},
+            {deleteACL: {$ne: unxGroup}},
+            {adminACL: {$ne: unxGroup}},
+          ],
+        },
+      },
+    },
+    {
+      $addFields: {
+        descendants: {
+          $concatArrays: [['$$ROOT'], '$descendants'],
+        },
+      },
+    },
+    {
+      $project: {
+        'descendants._id': 1,
+      },
+    },
+    {$unwind: '$descendants'},
+    {$replaceRoot: {newRoot: '$descendants'}},
+  ];
+}


### PR DESCRIPTION
As there is a logic that takes the unxGroup from functional accounts for a given location and adds it to all logbooks that are descendants of that location, this PR takes into account the case where a functional account with a location and a unxGroup is created after the logbooks referencing that location already exist. In this case it should propagate the unxGroups to the existing logbooks