### PR TITLE
Require admin authorization for POST /users

### DIFF
--- a/sci-log-db/src/controllers/user.controller.ts
+++ b/sci-log-db/src/controllers/user.controller.ts
@@ -56,6 +56,7 @@ export class UserController {
   ) {}
 
   @post('/users', {
+    security: OPERATION_SECURITY_SPEC,
     responses: {
       '200': {
         description: 'User',
@@ -68,6 +69,11 @@ export class UserController {
         },
       },
     },
+  })
+  @authenticate('jwt')
+  @authorize({
+    allowedRoles: ['admin'],
+    voters: [basicAuthorization],
   })
   async create(
     @requestBody({


### PR DESCRIPTION
### Vulnerability
The POST /users endpoint in SciLog is unauthenticated, hence, an attacker is able to create a user (functional account) with admin rights.
https://scilog.psi.ch/api/v1/explorer/#/UserController/UserController.create 
 
Logging in with the created functional account https://scilog.psi.ch/login (username: [scilog-admin@YOURDOMAIN](mailto:scilog-admin@YOURDOMAIN) and password: xxx). Able to view / delete all Logbooks

### Fix
Added admin authorization to /users endpoint. Fixed and added corresponding tests