### PR TITLE
SciCat Dataset widget

### DIFF
--- a/scilog/.gitignore
+++ b/scilog/.gitignore
@@ -63,3 +63,5 @@ typings/
 
 # Cache used by TypeScript's incremental build
 *.tsbuildinfo
+
+.vscode

--- a/scilog/package-lock.json
+++ b/scilog/package-lock.json
@@ -48,6 +48,7 @@
         "@angular-devkit/build-angular": "^15.2.11",
         "@angular/cli": "^15.2.11",
         "@angular/compiler-cli": "^15.2.10",
+        "@scicatproject/scicat-sdk-ts-fetch": "^4.13.0",
         "@types/jasmine": "~3.6.0",
         "@types/jasminewd2": "~2.0.3",
         "@types/node": "^12.11.1",
@@ -4889,6 +4890,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
+    "node_modules/@scicatproject/scicat-sdk-ts-fetch": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@scicatproject/scicat-sdk-ts-fetch/-/scicat-sdk-ts-fetch-4.13.0.tgz",
+      "integrity": "sha512-eFnO1WMTerxCJOV7iwNUBNH1Xaney+yvCYnEqT/e8rWwp7vNeNabIvPkm8P3991mp5penaszPLxpfAtRpkTqJQ==",
       "dev": true
     },
     "node_modules/@sigstore/bundle": {
@@ -20955,6 +20962,12 @@
           "dev": true
         }
       }
+    },
+    "@scicatproject/scicat-sdk-ts-fetch": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@scicatproject/scicat-sdk-ts-fetch/-/scicat-sdk-ts-fetch-4.13.0.tgz",
+      "integrity": "sha512-eFnO1WMTerxCJOV7iwNUBNH1Xaney+yvCYnEqT/e8rWwp7vNeNabIvPkm8P3991mp5penaszPLxpfAtRpkTqJQ==",
+      "dev": true
     },
     "@sigstore/bundle": {
       "version": "1.1.0",

--- a/scilog/package.json
+++ b/scilog/package.json
@@ -54,6 +54,7 @@
     "@angular-devkit/build-angular": "^15.2.11",
     "@angular/cli": "^15.2.11",
     "@angular/compiler-cli": "^15.2.10",
+    "@scicatproject/scicat-sdk-ts-fetch": "^4.13.0",
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",

--- a/scilog/src/app/app-config.service.ts
+++ b/scilog/src/app/app-config.service.ts
@@ -12,6 +12,8 @@ export interface AppConfig {
   lbBaseURL?: string;
   oAuth2Endpoint?: Oauth2Endpoint;
   help?: string;
+  scicatLbBaseURL?: string;
+  scicatFrontendBaseURL?: string;
 }
 
 @Injectable()
@@ -24,7 +26,7 @@ export class AppConfigService {
       try {
         this.appConfig = await this.http.get("/assets/config.json").toPromise();
       } catch (err) {
-        console.error("No config provided, applying defaults");
+        console.error("No config provided, applying defaults", err);
       }
   }
 

--- a/scilog/src/app/app-config.service.ts
+++ b/scilog/src/app/app-config.service.ts
@@ -8,12 +8,17 @@ export interface Oauth2Endpoint {
   displayImage?: string,
   tooltipText?: string,
 }
+export interface ScicatSettings {
+  scicatWidgetEnabled: boolean;
+  lbBaseURL: string;
+  frontendBaseURL: string;
+}
+
 export interface AppConfig {
   lbBaseURL?: string;
   oAuth2Endpoint?: Oauth2Endpoint;
   help?: string;
-  scicatLbBaseURL?: string;
-  scicatFrontendBaseURL?: string;
+  scicat?: ScicatSettings;
 }
 
 @Injectable()
@@ -32,5 +37,9 @@ export class AppConfigService {
 
   getConfig(): AppConfig {
     return this.appConfig as AppConfig;
+  }
+
+  getScicatSettings(): ScicatSettings | undefined {
+    return (this.appConfig as AppConfig).scicat;
   }
 }

--- a/scilog/src/app/app-routing.module.ts
+++ b/scilog/src/app/app-routing.module.ts
@@ -15,10 +15,12 @@ import { ViewSettingsComponent } from '@shared/settings/view-settings/view-setti
 import { ProfileSettingsComponent } from '@shared/settings/profile-settings/profile-settings.component';
 import { DownloadComponent } from '@shared/download/download.component';
 import { NavigationGuardService } from './logbook/core/navigation-guard-service';
+import { AuthCallbackComponent } from './auth-callback/auth-callback.component';
 
 const routes: Routes = [
   { path: '', redirectTo: '/login', pathMatch: 'full' },
   { path: 'login', component: LoginComponent },
+  { path: 'auth-callback', component: AuthCallbackComponent },
   { path: 'overview', component: OverviewComponent },
   { path: 'download/:fileId', component: DownloadComponent },
   { path: 'logbooks/:logbookId', component: LogbookComponent,

--- a/scilog/src/app/app.module.ts
+++ b/scilog/src/app/app.module.ts
@@ -88,6 +88,8 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSortModule } from '@angular/material/sort';
 import { OverviewScrollComponent } from './overview/overview-scroll/overview-scroll.component';
 import { ActionsMenuComponent } from './overview/actions-menu/actions-menu.component';
+import { ScicatViewerComponent } from './logbook/widgets/scicat-viewer/scicat-viewer.component';
+import { AuthCallbackComponent } from './auth-callback/auth-callback.component';
 
 const appConfigInitializerFn = (appConfig: AppConfigService) => {
     return () => appConfig.loadAppConfig();
@@ -135,7 +137,9 @@ const appConfigInitializerFn = (appConfig: AppConfigService) => {
         ResizedDirective,
         OverviewTableComponent,
         OverviewScrollComponent,
-        ActionsMenuComponent
+        ActionsMenuComponent,
+        ScicatViewerComponent,
+        AuthCallbackComponent
     ],
     imports: [
         BrowserModule,

--- a/scilog/src/app/auth-callback/auth-callback.component.html
+++ b/scilog/src/app/auth-callback/auth-callback.component.html
@@ -1,0 +1,1 @@
+<p>auth-callback works!</p>

--- a/scilog/src/app/auth-callback/auth-callback.component.spec.ts
+++ b/scilog/src/app/auth-callback/auth-callback.component.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AuthCallbackComponent } from './auth-callback.component';
+import { provideRouter, Router } from '@angular/router';
+import { Component } from '@angular/core';
+
+@Component({})
+class DummyComponent {}
+
+describe('AuthCallbackComponent', () => {
+  let component: AuthCallbackComponent;
+  let fixture: ComponentFixture<AuthCallbackComponent>;
+  let router: Router;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AuthCallbackComponent],
+      providers: [
+        provideRouter([
+          { path: 'overview', component: DummyComponent },
+          { path: 'auth-callback', component: AuthCallbackComponent },
+          { path: 'dashboard', component: DummyComponent },
+        ]),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AuthCallbackComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set scicat token and redirect to returnUrl', async () => {
+    const routerSpy = spyOn(router, 'navigateByUrl').and.callThrough();
+    await router.navigateByUrl(
+      '/auth-callback?access-token=123&returnUrl=/dashboard'
+    );
+    fixture.detectChanges();
+    expect(localStorage.getItem('scicat_token')).toEqual('123');
+    expect(routerSpy).toHaveBeenCalledWith('/dashboard');
+    localStorage.removeItem('scicat_token');
+  });
+
+  it('should should redirect to overview if no returnUrl', async () => {
+    const routerSpy = spyOn(router, 'navigate').and.callThrough();
+    await router.navigateByUrl('/auth-callback?access-token=123');
+    fixture.detectChanges();
+    expect(routerSpy).toHaveBeenCalledWith(['/overview']);
+  });
+});

--- a/scilog/src/app/auth-callback/auth-callback.component.ts
+++ b/scilog/src/app/auth-callback/auth-callback.component.ts
@@ -1,0 +1,36 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'app-auth-callback',
+  template: '',
+  styles: [],
+})
+export class AuthCallbackComponent implements OnInit, OnDestroy {
+  constructor(private route: ActivatedRoute, private router: Router) {}
+
+  subscriptions: Subscription[] = [];
+
+  ngOnInit(): void {
+    const sub = this.route.queryParams.subscribe((params) => {
+      const token = params['access-token'];
+      const returnUrl = params['returnUrl'];
+
+      if (token) {
+        localStorage.setItem('scicat_token', token);
+      }
+
+      if (returnUrl) {
+        this.router.navigateByUrl(returnUrl);
+      } else {
+        this.router.navigate(['/overview']);
+      }
+    });
+    this.subscriptions.push(sub);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+  }
+}

--- a/scilog/src/app/core/auth-services/auth.interceptor.spec.ts
+++ b/scilog/src/app/core/auth-services/auth.interceptor.spec.ts
@@ -1,16 +1,63 @@
 import { TestBed } from '@angular/core/testing';
 
 import { AuthInterceptor } from './auth.interceptor';
+import { ServerSettingsService } from '@shared/config/server-settings.service';
+import { HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
+import { of } from 'rxjs';
 
 describe('AuthInterceptor', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    providers: [
-      AuthInterceptor
-      ]
-  }));
+  const serverSettingsService = jasmine.createSpyObj('ServerSettingsService', [
+    'getSciCatServerAddress',
+  ]);
+  serverSettingsService.getSciCatServerAddress.and.returnValue(
+    'https://scicat-backend.psi.ch'
+  );
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      providers: [
+        AuthInterceptor,
+        { provide: ServerSettingsService, useValue: serverSettingsService },
+      ],
+    })
+  );
 
   it('should be created', () => {
     const interceptor: AuthInterceptor = TestBed.inject(AuthInterceptor);
     expect(interceptor).toBeTruthy();
   });
+
+  it('should append scicat token if request to scicat backend', (done: DoneFn) => {
+    localStorage.setItem('scicat_token', 'test_scicat_token');
+    const interceptor: AuthInterceptor = TestBed.inject(AuthInterceptor);
+    const req = new HttpRequest("GET", 'https://scicat-backend.psi.ch/api/v3/datasets');
+    const next = jasmine.createSpyObj<HttpHandler>('HttpHandler', ['handle']);
+    next.handle.and.returnValue(of({} as HttpEvent<any>));
+    interceptor.intercept(req, next).subscribe({
+      next: (_httpEvent: HttpEvent<any>) => {
+        const reqArg = next.handle.calls.mostRecent().args[0];
+        expect(reqArg.headers.get('Authorization')).toBe('Bearer test_scicat_token');
+        localStorage.clear();
+        done();
+      },
+      error: done.fail,
+    });
+  });
+
+  it('should append scilog token if request is not to scicat backend', (done: DoneFn) => {
+    localStorage.setItem('id_token', 'test_scilog_token');
+    const interceptor: AuthInterceptor = TestBed.inject(AuthInterceptor);
+    const req = new HttpRequest("GET", 'https://scilog-backend.psi.ch/api/v1');
+    const next = jasmine.createSpyObj<HttpHandler>('HttpHandler', ['handle']);
+    next.handle.and.returnValue(of({} as HttpEvent<any>));
+    interceptor.intercept(req, next).subscribe({
+      next: (_httpEvent: HttpEvent<any>) => {
+        const reqArg = next.handle.calls.mostRecent().args[0];
+        expect(reqArg.headers.get('Authorization')).toBe('Bearer test_scilog_token');
+        localStorage.clear();
+        done();
+      },
+      error: done.fail,
+    });
+  });
 });
+

--- a/scilog/src/app/core/auth-services/auth.interceptor.ts
+++ b/scilog/src/app/core/auth-services/auth.interceptor.ts
@@ -1,57 +1,85 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import {
   HttpRequest,
   HttpHandler,
   HttpEvent,
   HttpInterceptor,
   HttpResponse,
-  HttpErrorResponse
+  HttpErrorResponse,
 } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
+import { ServerSettingsService } from '@shared/config/server-settings.service';
 
 function logout() {
-  localStorage.removeItem("id_token");
+  localStorage.removeItem('id_token');
   localStorage.removeItem('id_session');
+  localStorage.removeItem('scicat_token');
   sessionStorage.removeItem('scilog-auto-selection-logbook');
   location.href = '/login';
-};
-
-function handle_request(handler: HttpHandler, req: HttpRequest<any>) {
-  return handler.handle(req).pipe(tap((event: HttpEvent<any>) => {
-    if (event instanceof HttpResponse) {
-      // console.log(cloned);
-      // console.log("Service Response thr Interceptor");
-    }
-  }, (err: any) => {
-    if (err instanceof HttpErrorResponse) {
-      console.log("err.status", err);
-      if (err.status === 401) {
-        logout();
-      }
-    }
-  }));
 }
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
+  private serverSettingsService = inject(ServerSettingsService);
 
-  intercept(req: HttpRequest<any>,
-    next: HttpHandler): Observable<HttpEvent<any>> {
+  private isRequestToSciCatBackend(req_url: string): boolean {
+    try {
+      const origin = new URL(req_url).origin;
+      return (
+        origin ===
+        new URL(this.serverSettingsService.getSciCatServerAddress()).origin
+      );
+    } catch (err) {
+      // new URL(...) fails for request to static assets (e.g. /assets/config.json)
+      return false;
+    }
+  }
 
-    const idToken = localStorage.getItem("id_token");
+  private handle_request(handler: HttpHandler, req: HttpRequest<any>) {
+    return handler.handle(req).pipe(
+      tap({
+        next: (event: HttpEvent<any>) => {
+          if (event instanceof HttpResponse) {
+            // console.log(cloned);
+            // console.log("Service Response thr Interceptor");
+          }
+        },
+        error: (err: any) => {
+          if (err instanceof HttpErrorResponse) {
+            console.log('err.status', err);
+            if (err.status === 401) {
+              if (!this.isRequestToSciCatBackend(err.url)) {
+                logout();
+              } else {
+                window.location.href = `${this.serverSettingsService.getSciCatServerAddress()}/api/v3/auth/oidc?client=scilog&returnURL=${
+                  window.location.pathname + window.location.search
+                }`;
+              }
+            }
+          }
+        },
+      })
+    );
+  }
 
+  intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    let idToken = '';
+    if (this.isRequestToSciCatBackend(req.url)) {
+      idToken = localStorage.getItem('scicat_token');
+    } else {
+      idToken = localStorage.getItem('id_token');
+    }
     if (idToken) {
       const cloned = req.clone({
-        headers: req.headers.set("Authorization",
-          "Bearer " + idToken)
+        headers: req.headers.set('Authorization', 'Bearer ' + idToken),
       });
-
-      return handle_request(next, cloned);
-
-    }
-    else {
-      return handle_request(next, req);
+      return this.handle_request(next, cloned);
+    } else {
+      return this.handle_request(next, req);
     }
   }
 }

--- a/scilog/src/app/core/auth-services/auth.interceptor.ts
+++ b/scilog/src/app/core/auth-services/auth.interceptor.ts
@@ -52,9 +52,8 @@ export class AuthInterceptor implements HttpInterceptor {
               if (!this.isRequestToSciCatBackend(err.url)) {
                 logout();
               } else {
-                window.location.href = `${this.serverSettingsService.getSciCatServerAddress()}/api/v3/auth/oidc?client=scilog&returnURL=${
-                  window.location.pathname + window.location.search
-                }`;
+                const returnURL = window.location.pathname + window.location.search;
+                window.location.href = this.serverSettingsService.getScicatLoginUrl(returnURL);
               }
             }
           }

--- a/scilog/src/app/core/auth-services/auth.service.ts
+++ b/scilog/src/app/core/auth-services/auth.service.ts
@@ -31,6 +31,7 @@ export class AuthService {
   logout() {
       localStorage.removeItem("id_token");
       localStorage.removeItem('id_session');
+      localStorage.removeItem('scicat_token');
       sessionStorage.removeItem('scilog-auto-selection-logbook');
       this.forceReload=true;
   }

--- a/scilog/src/app/core/config/server-settings.service.ts
+++ b/scilog/src/app/core/config/server-settings.service.ts
@@ -14,6 +14,14 @@ export class ServerSettingsService {
     return this.appConfigService.getConfig().lbBaseURL ?? 'http://[::1]:3000/';
   }
 
+  getSciCatServerAddress() : string | undefined {
+    return this.appConfigService.getConfig().scicatLbBaseURL;
+  }
+
+  getScicatFrontendBaseUrl() : string | undefined {
+    return this.appConfigService.getConfig().scicatFrontendBaseURL;
+  }
+
   getSocketAddress(){
     const lbBaseURL = this.appConfigService.getConfig().lbBaseURL ?? 'http://localhost:3000/';
     if (!lbBaseURL.startsWith('http')) throw new Error('BaseURL must use the http or https protocol');

--- a/scilog/src/app/core/config/server-settings.service.ts
+++ b/scilog/src/app/core/config/server-settings.service.ts
@@ -2,30 +2,32 @@ import { Injectable } from '@angular/core';
 import { AppConfigService } from "../../app-config.service";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ServerSettingsService {
+  constructor(private appConfigService: AppConfigService) {}
 
-  constructor(
-    private appConfigService: AppConfigService,
-  ) { }
-
-  getServerAddress(){
+  getServerAddress() {
     return this.appConfigService.getConfig().lbBaseURL ?? 'http://[::1]:3000/';
   }
 
-  getSciCatServerAddress() : string | undefined {
-    return this.appConfigService.getConfig().scicatLbBaseURL;
+  getSciCatServerAddress(): string | undefined {
+    return this.appConfigService.getScicatSettings()?.lbBaseURL;
   }
 
-  getScicatFrontendBaseUrl() : string | undefined {
-    return this.appConfigService.getConfig().scicatFrontendBaseURL;
+  getScicatLoginUrl(returnURL: string): string {
+    return `${this.getSciCatServerAddress()}/api/v3/auth/oidc?client=scilog&returnURL=${returnURL}`;
   }
 
-  getSocketAddress(){
-    const lbBaseURL = this.appConfigService.getConfig().lbBaseURL ?? 'http://localhost:3000/';
-    if (!lbBaseURL.startsWith('http')) throw new Error('BaseURL must use the http or https protocol');
+  getScicatFrontendBaseUrl(): string | undefined {
+    return this.appConfigService.getScicatSettings()?.frontendBaseURL;
+  }
+
+  getSocketAddress() {
+    const lbBaseURL =
+      this.appConfigService.getConfig().lbBaseURL ?? 'http://localhost:3000/';
+    if (!lbBaseURL.startsWith('http'))
+      throw new Error('BaseURL must use the http or https protocol');
     return `ws${lbBaseURL.substring(4)}`;
   }
-
 }

--- a/scilog/src/app/core/dataset.service.spec.ts
+++ b/scilog/src/app/core/dataset.service.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DatasetService } from './dataset.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AppConfigService } from '../app-config.service';
+
+describe('DatasetService', () => {
+  let service: DatasetService;
+  const getConfig = () => ({});
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({imports: [HttpClientTestingModule], providers: [DatasetService, { provide: AppConfigService, useValue: { getConfig } }]});
+    service = TestBed.inject(DatasetService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/scilog/src/app/core/dataset.service.ts
+++ b/scilog/src/app/core/dataset.service.ts
@@ -1,0 +1,52 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ServerSettingsService } from './config/server-settings.service';
+import type {
+  OutputDatasetObsoleteDto,
+  ReturnedUserDto,
+} from '@scicatproject/scicat-sdk-ts-fetch';
+
+export type Dataset = OutputDatasetObsoleteDto;
+export type DatasetSummary = Pick<
+  Dataset,
+  'pid' | 'datasetName' | 'creationTime'
+>;
+export type ScicatUser = ReturnedUserDto;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DatasetService {
+  constructor(
+    private httpClient: HttpClient,
+    private serverSettingsService: ServerSettingsService
+  ) {}
+
+  getDatasets(): Observable<DatasetSummary[]> {
+    return this.httpClient.get<DatasetSummary[]>(
+      `${this.serverSettingsService.getSciCatServerAddress()}/api/v3/datasets`,
+      {
+        params: {
+          filter: JSON.stringify({
+            fields: ['pid', 'datasetName', 'creationTime'],
+          }),
+        },
+      }
+    );
+  }
+
+  getDataset(pid: string): Observable<Dataset> {
+    return this.httpClient.get<Dataset>(
+      `${this.serverSettingsService.getSciCatServerAddress()}/api/v3/datasets/${encodeURIComponent(
+        pid
+      )}`
+    );
+  }
+
+  getMyself(): Observable<ScicatUser> {
+    return this.httpClient.get<ScicatUser>(
+      `${this.serverSettingsService.getSciCatServerAddress()}/api/v3/users/my/self`
+    );
+  }
+}

--- a/scilog/src/app/core/dataset.service.ts
+++ b/scilog/src/app/core/dataset.service.ts
@@ -30,6 +30,7 @@ export class DatasetService {
         params: {
           filter: JSON.stringify({
             fields: ['pid', 'datasetName', 'creationTime'],
+            limits: { limit: 100, order: 'creationTime:desc' },
           }),
         },
       }
@@ -48,5 +49,11 @@ export class DatasetService {
     return this.httpClient.get<ScicatUser>(
       `${this.serverSettingsService.getSciCatServerAddress()}/api/v3/users/my/self`
     );
+  }
+
+  getDatasetDetailPageUrl(pid: string): string {
+    return `${this.serverSettingsService.getScicatFrontendBaseUrl()}/datasets/${encodeURIComponent(
+      pid
+    )}`;
   }
 }

--- a/scilog/src/app/logbook/dashboard/dashboard-item/dashboard-item.component.html
+++ b/scilog/src/app/logbook/dashboard/dashboard-item/dashboard-item.component.html
@@ -22,7 +22,7 @@
     <chart *ngSwitchCase="'graph'" [configIndex]="configIndex"></chart>
     <todos *ngSwitchCase="'tasks'" [configIndex]="configIndex"></todos>
     <snippet-viewer *ngSwitchCase="'snippetViewer'" [configIndex]="configIndex"></snippet-viewer>
-    <scicat-viewer *ngSwitchCase="'scicatViewer'" [configIndex]="configIndex"></scicat-viewer>
+    <scicat-viewer *ngSwitchCase="'scicatViewer'"></scicat-viewer>
     <div *ngSwitchDefault>
         No content specified.
     </div>

--- a/scilog/src/app/logbook/dashboard/dashboard-item/dashboard-item.component.html
+++ b/scilog/src/app/logbook/dashboard/dashboard-item/dashboard-item.component.html
@@ -22,6 +22,7 @@
     <chart *ngSwitchCase="'graph'" [configIndex]="configIndex"></chart>
     <todos *ngSwitchCase="'tasks'" [configIndex]="configIndex"></todos>
     <snippet-viewer *ngSwitchCase="'snippetViewer'" [configIndex]="configIndex"></snippet-viewer>
+    <scicat-viewer *ngSwitchCase="'scicatViewer'" [configIndex]="configIndex"></scicat-viewer>
     <div *ngSwitchDefault>
         No content specified.
     </div>

--- a/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.css
+++ b/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.css
@@ -1,0 +1,3 @@
+#dataset-details table th {
+  text-align: left;
+}

--- a/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.html
+++ b/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.html
@@ -1,0 +1,62 @@
+<div *ngIf="scicatUser; else unauthenticated">
+  <p>Your SciCat userId is {{ scicatUser.id }}.</p>
+</div>
+<ng-template #unauthenticated>
+  <p>Not authenticated with SciCat, showing only public datasets:</p>
+</ng-template>
+<div>
+  <mat-form-field
+    ><mat-label for="dataset-select">Select Dataset:</mat-label>
+    <mat-select id="dataset-select" (selectionChange)="onDatasetSelect($event)">
+      <mat-option
+        *ngFor="let dataset of datasetSummary"
+        [value]="dataset.pid"
+        >{{ dataset.datasetName }}</mat-option
+      >
+    </mat-select></mat-form-field
+  >
+</div>
+
+<div *ngIf="selectedDataset">
+  <mat-card appearance="outlined">
+    <div>
+      <mat-card-title>{{ selectedDataset.datasetName }}</mat-card-title>
+      <mat-card-subtitle>{{ selectedDataset.pid }}</mat-card-subtitle>
+    </div>
+    <mat-card-content id="dataset-details">
+      <p>{{ selectedDataset.description }}</p>
+      <table>
+        <tr>
+          <th>Creation time</th>
+          <td>
+            {{ selectedDataset.creationTime | date : "dd.MM.yyyy HH:mm" }}
+          </td>
+        </tr>
+        <tr>
+          <th>Creation location</th>
+          <td>{{ selectedDataset.creationLocation }}</td>
+        </tr>
+        <tr>
+          <th>Owner</th>
+          <td>{{ selectedDataset.owner }}</td>
+        </tr>
+        <tr>
+          <th>Principal investigators</th>
+          <td>{{ selectedDataset.principalInvestigator }}</td>
+        </tr>
+        <tr>
+          <th>Size</th>
+          <td>{{ selectedDataset.size }}</td>
+        </tr>
+      </table>
+    </mat-card-content>
+    <mat-card-actions>
+      <a mat-button [href]="scicatDatasetUrl" target="_blank"
+        >Open in SciCat <mat-icon>open_in_new</mat-icon></a
+      >
+    </mat-card-actions>
+  </mat-card>
+</div>
+<div *ngIf="datasetFetching">
+  <mat-spinner></mat-spinner>
+</div>

--- a/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.html
+++ b/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="scicatUser; else unauthenticated">
-  <p>Your SciCat userId is {{ scicatUser.id }}.</p>
+  <p>Hello, {{ scicatUser.username }}!</p>
 </div>
 <ng-template #unauthenticated>
   <p>Not authenticated with SciCat, showing only public datasets:</p>

--- a/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.spec.ts
+++ b/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ScicatViewerComponent } from './scicat-viewer.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { AppConfigService } from 'src/app/app-config.service';
+
+describe('ScicatViewerComponent', () => {
+  let component: ScicatViewerComponent;
+  let fixture: ComponentFixture<ScicatViewerComponent>;
+  const getConfig = () => ({});
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      declarations: [ScicatViewerComponent],
+      providers: [{ provide: AppConfigService, useValue: { getConfig } }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ScicatViewerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.spec.ts
+++ b/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.spec.ts
@@ -7,13 +7,13 @@ import { AppConfigService } from 'src/app/app-config.service';
 describe('ScicatViewerComponent', () => {
   let component: ScicatViewerComponent;
   let fixture: ComponentFixture<ScicatViewerComponent>;
-  const getConfig = () => ({});
+  const returnEmpty = () => ({});
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       declarations: [ScicatViewerComponent],
-      providers: [{ provide: AppConfigService, useValue: { getConfig } }],
+      providers: [{ provide: AppConfigService, useValue: { getConfig: returnEmpty, getScicatSettings: returnEmpty } }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ScicatViewerComponent);

--- a/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.ts
+++ b/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { MatLegacySelectChange } from '@angular/material/legacy-select';
-import { ServerSettingsService } from '@shared/config/server-settings.service';
 import {
   type Dataset,
   DatasetService,
@@ -14,10 +13,7 @@ import {
   styleUrls: ['./scicat-viewer.component.css'],
 })
 export class ScicatViewerComponent implements OnInit {
-  constructor(
-    private datasetService: DatasetService,
-    private serverSettingsService: ServerSettingsService
-  ) {}
+  constructor(private datasetService: DatasetService) {}
 
   scicatUser: ScicatUser | null = null;
   datasetSummary: DatasetSummary[] = [];
@@ -35,18 +31,14 @@ export class ScicatViewerComponent implements OnInit {
     });
 
     this.datasetService.getDatasets().subscribe((data: DatasetSummary[]) => {
-      this.datasetSummary = data.sort(
-        (a, b) =>
-          new Date(b.creationTime).getTime() -
-          new Date(a.creationTime).getTime()
-      );
+      this.datasetSummary = data;
     });
   }
 
   get scicatDatasetUrl(): string {
-    return `${this.serverSettingsService.getScicatFrontendBaseUrl()}/datasets/${encodeURIComponent(
+    return this.datasetService.getDatasetDetailPageUrl(
       this.selectedDataset?.pid
-    )}`;
+    );
   }
 
   onDatasetSelect(event: MatLegacySelectChange): void {

--- a/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.ts
+++ b/scilog/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnInit } from '@angular/core';
+import { MatLegacySelectChange } from '@angular/material/legacy-select';
+import { ServerSettingsService } from '@shared/config/server-settings.service';
+import {
+  type Dataset,
+  DatasetService,
+  type ScicatUser,
+  type DatasetSummary,
+} from '@shared/dataset.service';
+
+@Component({
+  selector: 'scicat-viewer',
+  templateUrl: './scicat-viewer.component.html',
+  styleUrls: ['./scicat-viewer.component.css'],
+})
+export class ScicatViewerComponent implements OnInit {
+  constructor(
+    private datasetService: DatasetService,
+    private serverSettingsService: ServerSettingsService
+  ) {}
+
+  scicatUser: ScicatUser | null = null;
+  datasetSummary: DatasetSummary[] = [];
+  selectedDataset: Dataset | null = null;
+  datasetFetching = false;
+
+  ngOnInit(): void {
+    this.datasetService.getMyself().subscribe({
+      next: (data: ScicatUser) => {
+        this.scicatUser = data;
+      },
+      error: (_err) => {
+        this.scicatUser = null;
+      },
+    });
+
+    this.datasetService.getDatasets().subscribe((data: DatasetSummary[]) => {
+      this.datasetSummary = data.sort(
+        (a, b) =>
+          new Date(b.creationTime).getTime() -
+          new Date(a.creationTime).getTime()
+      );
+    });
+  }
+
+  get scicatDatasetUrl(): string {
+    return `${this.serverSettingsService.getScicatFrontendBaseUrl()}/datasets/${encodeURIComponent(
+      this.selectedDataset?.pid
+    )}`;
+  }
+
+  onDatasetSelect(event: MatLegacySelectChange): void {
+    const selectedPid = event.value;
+    this.datasetFetching = true;
+    this.selectedDataset = null;
+    this.datasetService.getDataset(selectedPid).subscribe((data: Dataset) => {
+      this.selectedDataset = data;
+      this.datasetFetching = false;
+    });
+  }
+}

--- a/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.html
+++ b/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.html
@@ -21,7 +21,7 @@
         <mat-option value="graph">Graph</mat-option>
         <mat-option value="tasks">Tasks</mat-option>
         <mat-option value="snippetViewer">Snippet viewer</mat-option>
-
+        <mat-option value="scicatViewer">Scicat viewer</mat-option>
       </mat-select>
     </mat-form-field>
     <mat-divider></mat-divider>

--- a/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.html
+++ b/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.html
@@ -21,7 +21,7 @@
         <mat-option value="graph">Graph</mat-option>
         <mat-option value="tasks">Tasks</mat-option>
         <mat-option value="snippetViewer">Snippet viewer</mat-option>
-        <mat-option value="scicatViewer">Scicat viewer</mat-option>
+        <mat-option *ngIf="scicatWidgetEnabled" value="scicatViewer">Scicat viewer</mat-option>
       </mat-select>
     </mat-form-field>
     <mat-divider></mat-divider>

--- a/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.spec.ts
+++ b/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.spec.ts
@@ -9,6 +9,7 @@ import { WidgetPreferencesDataService, LogbookDataService } from '@shared/remote
 import { of } from 'rxjs';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { MatLegacyAutocompleteModule as MatAutocompleteModule } from '@angular/material/legacy-autocomplete';
+import { AppConfigService } from 'src/app/app-config.service';
 
 
 class UserPreferencesMock {
@@ -24,6 +25,7 @@ describe('WidgetPreferencesComponent', () => {
   let logbookSpy: any;
   let logbookDataSpy: any;
   let widgetPreferencesSpy: any;
+  const returnEmpty = () => ({});
 
 
   logbookSpy = jasmine.createSpyObj("LogbookInfoService", ["logbookInfo", "getAvailLogbooks"]);
@@ -38,39 +40,45 @@ describe('WidgetPreferencesComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [WidgetPreferencesComponent, CdkTextareaAutosize,],
+      declarations: [WidgetPreferencesComponent, CdkTextareaAutosize],
       imports: [MatDialogModule, MatAutocompleteModule],
       providers: [
         UntypedFormBuilder,
         { provide: MatDialogRef, useValue: MatDialogRef },
         {
-          provide: MAT_DIALOG_DATA, useValue: {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
             config: {
               general: {
                 type: 'logbook',
                 title: 'Logbook view',
               },
               filter: {
-                targetId: "12345parentID",
+                targetId: '12345parentID',
                 additionalLogbooks: [],
-                tags: []
+                tags: [],
               },
               view: {
                 order: ['defaultOrder ASC'],
                 hideMetadata: false,
-                showSnippetHeader: false
-              }
-            }
-          }
+                showSnippetHeader: false,
+              },
+            },
+          },
         },
         { provide: LogbookInfoService, useValue: logbookSpy },
         { provide: LogbookDataService, useValue: logbookDataSpy },
         { provide: UserPreferencesService, useClass: UserPreferencesMock },
-        { provide: WidgetPreferencesDataService, useValue: widgetPreferencesSpy },
-
-      ]
-    })
-      .compileComponents();
+        {
+          provide: WidgetPreferencesDataService,
+          useValue: widgetPreferencesSpy,
+        },
+        {
+          provide: AppConfigService,
+          useValue: { getConfig: returnEmpty, getScicatSettings: returnEmpty },
+        },
+      ],
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.ts
+++ b/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.ts
@@ -14,6 +14,7 @@ import { Logbooks } from '@model/logbooks';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { WidgetPreferencesDataService, LogbookDataService } from '@shared/remote-data.service';
 import { WidgetItemConfig } from '@model/config';
+import { AppConfigService } from 'src/app/app-config.service';
 
 @Component({
   selector: 'widget-preferences',
@@ -63,6 +64,7 @@ export class WidgetPreferencesComponent implements OnInit {
   @ViewChild('logbookInput') logbookInput: ElementRef<HTMLInputElement>;
 
   readonly separatorKeysCodes: number[] = [ENTER, COMMA, SPACE];
+  scicatWidgetEnabled: boolean;
 
   constructor(
     fb: UntypedFormBuilder,
@@ -73,7 +75,8 @@ export class WidgetPreferencesComponent implements OnInit {
     private logbookDataService: LogbookDataService,
     @Inject(MAT_DIALOG_DATA) data,
     private _ngZone: NgZone,
-    protected changeDetectorRef: ChangeDetectorRef) {
+    protected changeDetectorRef: ChangeDetectorRef,
+    private appConfigService: AppConfigService) {
     this.data = data.config;
     this.options = fb.group({
       hideRequired: this.hideRequiredControl,
@@ -85,7 +88,7 @@ export class WidgetPreferencesComponent implements OnInit {
       logbook: new UntypedFormControl(''),
       description: new UntypedFormControl({ value: "", disabled: true })
     });
-
+    this.scicatWidgetEnabled = this.appConfigService.getScicatSettings()?.scicatWidgetEnabled || false;
   }
 
   ngOnInit(): void {

--- a/scilog/src/app/login/login.component.html
+++ b/scilog/src/app/login/login.component.html
@@ -9,7 +9,7 @@
       <mat-tab-group mat-stretch-tabs="false" mat-align-tabs="center" fitInkBarToContent>
         <mat-tab label="{{oAuth2Endpoint.displayText}}" *ngIf="oAuth2Endpoint">
           <ng-template mat-tab-label>
-            <label matTooltip="{{ oAuth2Endpoint.toolTipText }}" matTooltipClass="example-tooltip-red1" [matTooltipPosition]="'above'">
+            <label matTooltip="{{ oAuth2Endpoint.tooltipText }}" matTooltipClass="example-tooltip-red1" [matTooltipPosition]="'above'">
               {{oAuth2Endpoint.displayText}}
             </label>
           </ng-template>

--- a/scilog/src/assets/config-example.json
+++ b/scilog/src/assets/config-example.json
@@ -4,5 +4,7 @@
         "authURL": "auth/keycloak",
         "displayText": "keycloak",
         "toolTipText": "text to display on top of OIDC login button"
-    }
+    },
+    "scicatLbBaseURL": "http://backend.localhost",
+    "scicatFrontendBaseURL": "http://localhost"
 }

--- a/scilog/src/assets/config-example.json
+++ b/scilog/src/assets/config-example.json
@@ -5,6 +5,9 @@
         "displayText": "keycloak",
         "toolTipText": "text to display on top of OIDC login button"
     },
-    "scicatLbBaseURL": "http://backend.localhost",
-    "scicatFrontendBaseURL": "http://localhost"
+    "scicat": {
+        "scicatWidgetEnabled": true,
+        "lbBaseURL": "http://backend.localhost",
+        "frontendBaseURL": "http://localhost"
+    }
 }


### PR DESCRIPTION
### Overview
This PR implements a widget that displays a user-selected dataset from SciCat. An interceptor is implemented to detect a call to scicat backend, and if unauthorized, to fetch a scicat token for the OIDC user. 
<img src="https://github.com/user-attachments/assets/a80b43ee-cb0b-46c6-8b3b-813a36ed63fd" height="250px">

### Implementation details
We use support added in https://github.com/SciCatProject/scicat-backend-next/pull/1714 and pass `scilog` as `clientId` and the current path as `returnURL` to SciCat (to /auth/oidc/login). SciCat then returns the access token to `<scilog-frontend>/auth-callback` (configured as successURL for clientId scilog in SciCat i.e. `OIDC_SCILOG_SUCCESS_URL`) along with the passed returnUrl. The AuthCallback component in Scilog then stores the scicat token and routes the frontend to /returnUrl.

A first implementation of Dataset viewer is added, along with link to the corresponding dataset page in SciCat.

Added dependency on [scicat-sdk-ts-fetch](https://www.npmjs.com/package/@scicatproject/scicat-sdk-ts-fetch) to get typing support for Scicat backend calls.

### JIRA issues addressed
- https://psich.atlassian.net/browse/DATACGRP-142
- https://psich.atlassian.net/browse/DATACGRP-146
- https://psich.atlassian.net/browse/DATACGRP-147
- https://psich.atlassian.net/browse/DATACGRP-145

### Testing
Added tests for AuthInterceptor and AuthCallbackComponent.