### PR TITLE
Fix global style error for mat-dialog-container

### DIFF
--- a/scilog/src/app/app.component.scss
+++ b/scilog/src/app/app.component.scss
@@ -56,13 +56,6 @@
       height: 100vh;
     }
 
-  ::ng-deep .mat-toolbar{
-    z-index: 998;
-    position: fixed;
-    height: 50px;
-    flex: 1 1 auto;
-  }
-
   .flexExpand {
     flex: 1 1 auto;
 }

--- a/scilog/src/app/core/toolbar/toolbar.component.html
+++ b/scilog/src/app/core/toolbar/toolbar.component.html
@@ -45,7 +45,7 @@
           <span [ngStyle]="{'font-weight':view.id == currentView ? 'bold' : 'normal' }">{{ view.name }}</span>
         </button>
       </ng-container>
-      <button mat-menu-item (click)="openViewSettings()">
+      <button mat-menu-item (click)="openSettings('viewSettings')">
         <mat-icon>save</mat-icon>
         <span>Save/Edit</span>
       </button>
@@ -62,7 +62,7 @@
       </span>
     </button>
     <mat-menu #menu="matMenu">
-      <button mat-menu-item (click)="openSettings()">
+      <button mat-menu-item (click)="openSettings('profileSettings')">
         <mat-icon>settings</mat-icon>
         <span>Settings</span>
       </button>

--- a/scilog/src/app/core/toolbar/toolbar.component.ts
+++ b/scilog/src/app/core/toolbar/toolbar.component.ts
@@ -115,6 +115,7 @@ export class ToolbarComponent implements OnInit {
     dialogConfig.autoFocus = false;
     dialogConfig.disableClose = true;
     dialogConfig.data = "profileSettings";
+    dialogConfig.panelClass = "app-full-bleed-dialog";
     const dialogRef = this.dialog.open(SettingsComponent, dialogConfig);
     this.subscriptions.push(dialogRef.afterClosed().subscribe(data => {
       console.log(data);
@@ -126,6 +127,7 @@ export class ToolbarComponent implements OnInit {
     dialogConfig.autoFocus = false;
     dialogConfig.disableClose = true;
     dialogConfig.data = "viewSettings";
+    dialogConfig.panelClass = "app-full-bleed-dialog";
     const dialogRef = this.dialog.open(SettingsComponent, dialogConfig);
     this.subscriptions.push(dialogRef.afterClosed().subscribe(data => {
       console.log(data);

--- a/scilog/src/app/core/toolbar/toolbar.component.ts
+++ b/scilog/src/app/core/toolbar/toolbar.component.ts
@@ -110,28 +110,15 @@ export class ToolbarComponent implements OnInit {
     this.openMenu.emit();
   }
 
-  openSettings() {
+  openSettings(settingsType: "profileSettings" | "viewSettings") {
     const dialogConfig = new MatDialogConfig();
     dialogConfig.autoFocus = false;
     dialogConfig.disableClose = true;
-    dialogConfig.data = "profileSettings";
+    dialogConfig.data = settingsType;
     dialogConfig.panelClass = "app-full-bleed-dialog";
     const dialogRef = this.dialog.open(SettingsComponent, dialogConfig);
     this.subscriptions.push(dialogRef.afterClosed().subscribe(data => {
       console.log(data);
-    }));
-  }
-
-  openViewSettings() {
-    const dialogConfig = new MatDialogConfig();
-    dialogConfig.autoFocus = false;
-    dialogConfig.disableClose = true;
-    dialogConfig.data = "viewSettings";
-    dialogConfig.panelClass = "app-full-bleed-dialog";
-    const dialogRef = this.dialog.open(SettingsComponent, dialogConfig);
-    this.subscriptions.push(dialogRef.afterClosed().subscribe(data => {
-      console.log(data);
-      console.log(this.views)
     }));
   }
 

--- a/scilog/src/app/logbook/core/settings/settings.component.css
+++ b/scilog/src/app/logbook/core/settings/settings.component.css
@@ -15,11 +15,6 @@
 
 }
 
-::ng-deep .mat-dialog-container{
-padding: 0px;
-border-radius: 8px;
-}
-
 .main-content {
 
     /* padding-bottom: 60px; */

--- a/scilog/src/app/logbook/core/settings/view-settings/view-edit/view-edit.component.css
+++ b/scilog/src/app/logbook/core/settings/view-settings/view-edit/view-edit.component.css
@@ -17,11 +17,6 @@
 
 }
 
-::ng-deep .mat-dialog-container{
-padding: 0px;
-border-radius: 8px;
-}
-
 .main-content {
 
     /* padding-bottom: 60px; */

--- a/scilog/src/app/logbook/core/settings/view-settings/view-settings.component.css
+++ b/scilog/src/app/logbook/core/settings/view-settings/view-settings.component.css
@@ -17,11 +17,6 @@
 
 }
 
-::ng-deep .mat-dialog-container{
-padding: 0px;
-border-radius: 8px;
-}
-
 .main-content {
 
     /* padding-bottom: 60px; */

--- a/scilog/src/styles.scss
+++ b/scilog/src/styles.scss
@@ -10,3 +10,4 @@ body { height: calc(100%); margin: 0; font-family: Roboto, "Helvetica Neue", san
 @import "styles/roboto.scss";
 @import "styles/material-icons.scss";
 @import "prismjs/themes/prism.css";
+@import "styles/global";

--- a/scilog/src/styles/_global.scss
+++ b/scilog/src/styles/_global.scss
@@ -1,0 +1,4 @@
+.app-full-bleed-dialog .mat-dialog-container {
+    padding: 0;
+    border-radius: 8px;
+}


### PR DESCRIPTION
`::ng-deep` should not be used as it makes the style global and breaks Angular's [ViewEncapsulation](https://angular.dev/guide/components/styling#viewencapsulationemulated), making it hard to reason about which style will apply to a given component. 
This results in a bug that: if clicks on `User settings` on the toolbar first, then opens the Widget preference in a logbook, the padding gets overriden to 0 because the User settings component exported a global style with ng-deep.
![Screenshot from 2025-05-06 15-59-48](https://github.com/user-attachments/assets/fa9f8802-1d96-41fe-bd95-4166789ae2e8)

Fixed this according to this [SO answer](https://stackoverflow.com/a/45933595/6459429).  