### PR TITLE
(fix) update returnURL to returnUrl due to changed query parameter name in SciCat

### DIFF
--- a/scilog/src/app/core/auth-services/auth.interceptor.ts
+++ b/scilog/src/app/core/auth-services/auth.interceptor.ts
@@ -52,8 +52,8 @@ export class AuthInterceptor implements HttpInterceptor {
               if (!this.isRequestToSciCatBackend(err.url)) {
                 logout();
               } else {
-                const returnURL = window.location.pathname + window.location.search;
-                window.location.href = this.serverSettingsService.getScicatLoginUrl(returnURL);
+                const returnUrl = window.location.pathname + window.location.search;
+                window.location.href = this.serverSettingsService.getScicatLoginUrl(returnUrl);
               }
             }
           }

--- a/scilog/src/app/core/config/server-settings.service.ts
+++ b/scilog/src/app/core/config/server-settings.service.ts
@@ -15,8 +15,8 @@ export class ServerSettingsService {
     return this.appConfigService.getScicatSettings()?.lbBaseURL;
   }
 
-  getScicatLoginUrl(returnURL: string): string {
-    return `${this.getSciCatServerAddress()}/api/v3/auth/oidc?client=scilog&returnURL=${returnURL}`;
+  getScicatLoginUrl(returnUrl: string): string {
+    return `${this.getSciCatServerAddress()}/api/v3/auth/oidc?client=scilog&returnUrl=${returnUrl}`;
   }
 
   getScicatFrontendBaseUrl(): string | undefined {


### PR DESCRIPTION
Recently, the returnUrl query parameter name in `/v3/auth/oidc` endpoint was updated: https://github.com/SciCatProject/scicat-backend-next/pull/1815. Updating it here as well, to preserve the intended behavior (that the user lands on the opened logbook after authenticating with SciCat and not on overview page.)