### PR TITLE
(feat) ability to sort logbooks by last touched

### DIFF
--- a/sci-log-db/src/__tests__/acceptance/logbook.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/logbook.controller.acceptance.ts
@@ -229,6 +229,29 @@ describe('Logbook', function (this: Suite) {
       .expect(204);
   });
 
+  it('should touch snippet by id with token and update touchedAt', async () => {
+    const timeBefore = new Date();
+    await client
+      .patch(`/logbooks/${logbookSnippetId}/touch`)
+      .set('Authorization', 'Bearer ' + token)
+      .set('Content-Type', 'application/json')
+      .expect(204);
+    await client
+      .get(`/logbooks/${logbookSnippetId}`)
+      .set('Authorization', 'Bearer ' + token)
+      .set('Content-Type', 'application/json')
+      .expect(200)
+      .then(result => {
+        expect(result.body.id).to.eql(logbookSnippetId);
+        const touchedAt = new Date(result.body.touchedAt);
+        expect(touchedAt).to.be.a.Date();
+        expect(touchedAt.getTime()).to.be.greaterThan(timeBefore.getTime());
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
   it('Search index with token should return 200 and zero matches', async () => {
     const includeTags = {fields: {tags: true}};
     await client

--- a/sci-log-db/src/controllers/logbook.controller.ts
+++ b/sci-log-db/src/controllers/logbook.controller.ts
@@ -209,6 +209,22 @@ export class LogbookController {
     });
   }
 
+  @patch('/logbooks/{id}/touch', {
+    security: OPERATION_SECURITY_SPEC,
+    responses: {
+      '204': {
+        description: 'Logbook TOUCH success',
+      },
+    },
+  })
+  async touchLogbook(@param.path.string('id') id: string): Promise<void> {
+    await this.logbookRepository.updateById(
+      id,
+      {touchedAt: new Date()},
+      {currentUser: this.user, touched: true},
+    );
+  }
+
   @del('/logbooks/{id}', {
     security: OPERATION_SECURITY_SPEC,
     responses: {

--- a/sci-log-db/src/models/logbook.model.ts
+++ b/sci-log-db/src/models/logbook.model.ts
@@ -47,6 +47,12 @@ export class Logbook extends Basesnippet {
   })
   location: string;
 
+  @property({
+    type: 'date',
+    index: true,
+  })
+  touchedAt: Date;
+
   constructor(data?: Partial<Logbook>) {
     super(data);
   }

--- a/sci-log-db/src/repositories/autoadd.repository.base.ts
+++ b/sci-log-db/src/repositories/autoadd.repository.base.ts
@@ -306,8 +306,8 @@ export class AutoAddRepository<
         // console.log("PATCH case")
         if (!ctx.options.touched) {
           ctx.data.updatedAt = new Date();
+          ctx.data.updatedBy = currentUser?.email ?? 'unknown@domain.org';
         }
-        ctx.data.updatedBy = currentUser?.email ?? 'unknown@domain.org';
         // remove all auto generated fields
         delete ctx.data.createdAt;
         delete ctx.data.createdBy;

--- a/sci-log-db/src/repositories/autoadd.repository.base.ts
+++ b/sci-log-db/src/repositories/autoadd.repository.base.ts
@@ -304,7 +304,9 @@ export class AutoAddRepository<
       // PATCH case
       if (ctx.data) {
         // console.log("PATCH case")
-        ctx.data.updatedAt = new Date();
+        if (!ctx.options.touched) {
+          ctx.data.updatedAt = new Date();
+        }
         ctx.data.updatedBy = currentUser?.email ?? 'unknown@domain.org';
         // remove all auto generated fields
         delete ctx.data.createdAt;

--- a/scilog/src/app/core/remote-data.service.ts
+++ b/scilog/src/app/core/remote-data.service.ts
@@ -29,8 +29,8 @@ export class RemoteDataService {
     return `${this.serverSettings.getServerAddress()}/images`
   }
 
-  constructor(private httpClient: HttpClient,
-    private serverSettings: ServerSettingsService) { }
+  constructor(protected httpClient: HttpClient,
+    protected serverSettings: ServerSettingsService) { }
 
   protected deleteSnippet(snippetPath: string, snippetId: string) {
     return this.httpClient.delete(this.serverSettings.getServerAddress() + snippetPath + "/" + snippetId);
@@ -313,6 +313,11 @@ export class LogbookDataService extends RemoteDataService {
   patchLogbook(logbookId: string, payload: any): Promise<Logbooks> {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
     return this.patchSnippet<Logbooks>('logbooks', logbookId, JSON.stringify(payload), headers).toPromise();
+  }
+
+  touchLogbook(logbookId: string): Promise<void> {
+    const headers = new HttpHeaders().set('Content-Type', 'application/json');
+    return this.httpClient.patch<void>(this.serverSettings.getServerAddress() + 'logbooks/' + logbookId + '/touch', {}, { headers }).toPromise();
   }
 
   postLogbook(payload: any): Promise<Logbooks> {

--- a/scilog/src/app/logbook/logbook.component.spec.ts
+++ b/scilog/src/app/logbook/logbook.component.spec.ts
@@ -46,4 +46,9 @@ describe('LogbookComponent', () => {
     expect(component.sidenavOver).toEqual('side');
   });
 
+  it('should call touchLogbook on init', () => {
+    const logbookDataServiceSpy = spyOn(component['logbookDataService'], 'touchLogbook').and.callThrough();
+    component.ngOnInit();
+    expect(logbookDataServiceSpy).toHaveBeenCalledWith(component.logbookId);
+  });
 });

--- a/scilog/src/app/logbook/logbook.component.ts
+++ b/scilog/src/app/logbook/logbook.component.ts
@@ -18,6 +18,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatDivider } from '@angular/material/divider';
 import { NavigationButtonComponent } from './navigation-button/navigation-button.component';
 import { NgStyle } from '@angular/common';
+import { LogbookDataService } from '@shared/remote-data.service';
 
 @Component({
     selector: 'app-logbook',
@@ -57,6 +58,7 @@ export class LogbookComponent implements OnInit, OnDestroy {
   constructor(
     private route: ActivatedRoute,
     private logbookInfo: LogbookInfoService,
+    private logbookDataService: LogbookDataService,
     private tasks: TasksService,
     private views: ViewsService,
     private router: Router,
@@ -105,6 +107,9 @@ export class LogbookComponent implements OnInit, OnDestroy {
       console.log('logbook: ', this.logbookId);
     }));
     this.updateLogbookInfo();
+    this.logbookDataService.touchLogbook(this.logbookId).catch(() => {
+      console.error('Error touching logbook');
+    });
   }
 
   async updateLogbookInfo(){

--- a/scilog/src/app/logbook/logbook.component.ts
+++ b/scilog/src/app/logbook/logbook.component.ts
@@ -105,11 +105,11 @@ export class LogbookComponent implements OnInit, OnDestroy {
     this.subscriptions.push(this.route.paramMap.subscribe(params => {
       this.logbookId = params.get('logbookId');
       console.log('logbook: ', this.logbookId);
+      this.updateLogbookInfo();
+      this.logbookDataService.touchLogbook(this.logbookId).catch(() => {
+        console.error('Error touching logbook');
+      });
     }));
-    this.updateLogbookInfo();
-    this.logbookDataService.touchLogbook(this.logbookId).catch(() => {
-      console.error('Error touching logbook');
-    });
   }
 
   async updateLogbookInfo(){

--- a/scilog/src/app/overview/overview-table/overview-table.component.html
+++ b/scilog/src/app/overview/overview-table/overview-table.component.html
@@ -29,10 +29,19 @@
     </ng-container>
 
     <ng-container matColumnDef="createdAt">
-      <th mat-header-cell cdkDrag *matHeaderCellDef mat-sort-header>Date </th>
+      <th mat-header-cell cdkDrag *matHeaderCellDef mat-sort-header>Created on </th>
       <td mat-cell *matCellDef="let row">
         <div class="scrollable-text">
           {{row.createdAt | date}}
+        </div>
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="touchedAt">
+      <th mat-header-cell cdkDrag *matHeaderCellDef mat-sort-header>Last opened </th>
+      <td mat-cell *matCellDef="let row">
+        <div class="scrollable-text">
+          {{row.touchedAt | date}}
         </div>
       </td>
     </ng-container>

--- a/scilog/src/app/overview/overview-table/overview-table.component.spec.ts
+++ b/scilog/src/app/overview/overview-table/overview-table.component.spec.ts
@@ -71,9 +71,9 @@ describe('OverviewTableComponent', () => {
   });
 
   it('should test drop', () => {
-    expect(component.displayedColumns).toEqual(['name', 'description', 'ownerGroup', 'createdAt', 'thumbnail', 'actions']);
+    expect(component.displayedColumns).toEqual(['name', 'description', 'ownerGroup', 'touchedAt', 'createdAt', 'thumbnail', 'actions']);
     component.drop({ previousIndex: 1, currentIndex: 2 } as CdkDragDrop<string[]>);
-    expect(component.displayedColumns).toEqual(['name', 'ownerGroup', 'description', 'createdAt', 'thumbnail', 'actions']);
+    expect(component.displayedColumns).toEqual(['name', 'ownerGroup', 'description', 'touchedAt', 'createdAt', 'thumbnail', 'actions']);
   });
 
   [undefined, '123'].forEach(t => {

--- a/scilog/src/app/overview/overview-table/overview-table.component.ts
+++ b/scilog/src/app/overview/overview-table/overview-table.component.ts
@@ -28,7 +28,7 @@ export class OverviewTableComponent implements OnInit, AfterViewInit {
 
   dataSource: MatTableDataSource<Logbooks>;
   totalItems: number;
-  displayedColumns = ['name', 'description', 'ownerGroup', 'createdAt', 'thumbnail', 'actions'];
+  displayedColumns = ['name', 'description', 'ownerGroup', 'touchedAt', 'createdAt', 'thumbnail', 'actions'];
   private _config: WidgetItemConfig;
   isLoaded: boolean;
 

--- a/scilog/src/app/overview/overview.component.ts
+++ b/scilog/src/app/overview/overview.component.ts
@@ -153,7 +153,7 @@ export class OverviewComponent implements OnInit, OnDestroy {
         readonly: true
       },
       view: {
-        order: ["defaultOrder DESC"],
+        order: ["touchedAt DESC"],
         hideMetadata: false,
         showSnippetHeader: false
       }


### PR DESCRIPTION
### Backend
- Added an indexed `touchedAt` field to Logbook model
- Added an endpoint `PATCH /logbooks/{id}/touch` which updates the `touchedAt` to current time
- Added acceptance test for the endpoint

### Frontend
- Added a client method for the touch endpoint in LogbookDataService
- Calling the touch endpoint whenever the logbook page is visited
- Added an additional field `Last opened` in the overview-table
- Make default sort order `touchedAt DESC` rather than previous defaultOrder

Tested locally that the table filter works as expected, and in the overview scroll the last touched logbooks bubble to the top