### PR TITLE
Use scicat-sdk-ts-angular instead of ts-fetch

### DIFF
--- a/scilog/package-lock.json
+++ b/scilog/package-lock.json
@@ -52,7 +52,7 @@
         "@angular-eslint/template-parser": "19.7.0",
         "@angular/cli": "^19.2.14",
         "@angular/compiler-cli": "^19.2.14",
-        "@scicatproject/scicat-sdk-ts-fetch": "^4.13.0",
+        "@scicatproject/scicat-sdk-ts-angular": "^4.25.1",
         "@types/jasmine": "~3.6.0",
         "@types/jasminewd2": "~2.0.3",
         "@types/node": "^22.15.29",
@@ -6955,11 +6955,19 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@scicatproject/scicat-sdk-ts-fetch": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@scicatproject/scicat-sdk-ts-fetch/-/scicat-sdk-ts-fetch-4.17.0.tgz",
-      "integrity": "sha512-+TnsHNK5e6K9qN06b4aSUj/guFm/j9GwuqXLc02FZAyTTaaCKYEVdmsMLZb1vbgC6v0sxZb9hevR5e0qWxbpUg==",
-      "dev": true
+    "node_modules/@scicatproject/scicat-sdk-ts-angular": {
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/@scicatproject/scicat-sdk-ts-angular/-/scicat-sdk-ts-angular-4.25.1.tgz",
+      "integrity": "sha512-HvY4U0cF4Yv5MF+blpYmRqqY3/rbYnmNeCpeYHhTsJ/2BxO9LyQmjIPTiHgVPreEdtwDOPBb156DU3aZwAm3Kg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^19.0.0",
+        "rxjs": "^7.4.0"
+      }
     },
     "node_modules/@sigstore/bundle": {
       "version": "3.1.0",

--- a/scilog/package.json
+++ b/scilog/package.json
@@ -58,7 +58,7 @@
     "@angular-eslint/template-parser": "19.7.0",
     "@angular/cli": "^19.2.14",
     "@angular/compiler-cli": "^19.2.14",
-    "@scicatproject/scicat-sdk-ts-fetch": "^4.13.0",
+    "@scicatproject/scicat-sdk-ts-angular": "^4.25.1",
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^22.15.29",

--- a/scilog/src/app/core/dataset.service.ts
+++ b/scilog/src/app/core/dataset.service.ts
@@ -1,11 +1,12 @@
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ServerSettingsService } from './config/server-settings.service';
-import type {
+import {
+  DatasetsService,
   OutputDatasetObsoleteDto,
   ReturnedUserDto,
-} from '@scicatproject/scicat-sdk-ts-fetch';
+  UsersService,
+} from '@scicatproject/scicat-sdk-ts-angular';
 
 export type Dataset = OutputDatasetObsoleteDto;
 export type DatasetSummary = Pick<
@@ -19,36 +20,25 @@ export type ScicatUser = ReturnedUserDto;
 })
 export class DatasetService {
   constructor(
-    private httpClient: HttpClient,
-    private serverSettingsService: ServerSettingsService
+    private serverSettingsService: ServerSettingsService,
+    private datasetsService: DatasetsService,
+    private usersService: UsersService
   ) {}
 
   getDatasets(): Observable<DatasetSummary[]> {
-    return this.httpClient.get<DatasetSummary[]>(
-      `${this.serverSettingsService.getSciCatServerAddress()}/api/v3/datasets`,
-      {
-        params: {
-          filter: JSON.stringify({
-            fields: ['pid', 'datasetName', 'creationTime'],
-            limits: { limit: 100, order: 'creationTime:desc' },
-          }),
-        },
-      }
-    );
+    const filter = JSON.stringify({
+      fields: ['pid', 'datasetName', 'creationTime'],
+      limits: { limit: 100, order: 'creationTime:desc' },
+    });
+    return this.datasetsService.datasetsControllerFindAllV3(filter);
   }
 
   getDataset(pid: string): Observable<Dataset> {
-    return this.httpClient.get<Dataset>(
-      `${this.serverSettingsService.getSciCatServerAddress()}/api/v3/datasets/${encodeURIComponent(
-        pid
-      )}`
-    );
+    return this.datasetsService.datasetsControllerFindByIdV3(pid);
   }
 
   getMyself(): Observable<ScicatUser> {
-    return this.httpClient.get<ScicatUser>(
-      `${this.serverSettingsService.getSciCatServerAddress()}/api/v3/users/my/self`
-    );
+    return this.usersService.usersControllerGetMyUserV3() as Observable<ScicatUser>;
   }
 
   getDatasetDetailPageUrl(pid: string): string {

--- a/scilog/src/main.ts
+++ b/scilog/src/main.ts
@@ -1,9 +1,17 @@
-import { enableProdMode, provideAppInitializer, inject, importProvidersFrom } from '@angular/core';
-
+import {
+  enableProdMode,
+  provideAppInitializer,
+  inject,
+  importProvidersFrom,
+} from '@angular/core';
 
 import { environment } from './environments/environment';
 import { AppConfigService } from './app/app-config.service';
-import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import {
+  HTTP_INTERCEPTORS,
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
 import { AuthInterceptor } from '@shared/auth-services/auth.interceptor';
 import { AuthService } from '@shared/auth-services/auth.service';
 import { Router } from '@angular/router';
@@ -13,49 +21,58 @@ import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
 import { AppRoutingModule } from './app/app-routing.module';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { AppComponent } from './app/app.component';
+import { ApiModule, Configuration } from '@scicatproject/scicat-sdk-ts-angular';
 
 const appConfigInitializerFn = (appConfig: AppConfigService) => {
-    return () => appConfig.loadAppConfig();
+  return () => appConfig.loadAppConfig();
 };
 
-
+const apiConfigurationFn = (configurationService: AppConfigService) =>
+  new Configuration({
+    basePath: configurationService.getScicatSettings().lbBaseURL,
+  });
 
 if (environment.production) {
   enableProdMode();
 }
 
 bootstrapApplication(AppComponent, {
-    providers: [
-        importProvidersFrom(BrowserModule, AppRoutingModule),
-        AppConfigService,
-        provideAppInitializer(() => {
-            const initializerFn = (appConfigInitializerFn)(inject(AppConfigService));
-            return initializerFn();
-        }),
-        {
-            provide: HTTP_INTERCEPTORS,
-            useClass: AuthInterceptor,
-            multi: true,
-            deps: [AuthService, Router],
+  providers: [
+    importProvidersFrom(BrowserModule, AppRoutingModule, ApiModule),
+    AppConfigService,
+    provideAppInitializer(() => {
+      const initializerFn = appConfigInitializerFn(inject(AppConfigService));
+      return initializerFn();
+    }),
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AuthInterceptor,
+      multi: true,
+      deps: [AuthService, Router],
+    },
+    CookieService,
+    {
+      // Custom identicon style
+      provide: JDENTICON_CONFIG,
+      useValue: {
+        lightness: {
+          color: [0.31, 0.54],
+          grayscale: [0.63, 0.82],
         },
-        CookieService,
-        {
-            // Custom identicon style
-            provide: JDENTICON_CONFIG,
-            useValue: {
-                lightness: {
-                    color: [0.31, 0.54],
-                    grayscale: [0.63, 0.82],
-                },
-                saturation: {
-                    color: 0.50,
-                    grayscale: 0.50,
-                },
-                backColor: '#222',
-            },
+        saturation: {
+          color: 0.5,
+          grayscale: 0.5,
         },
-        provideHttpClient(withInterceptorsFromDi()),
-        provideAnimations()
-    ]
-})
-  .catch(err => console.error(err));
+        backColor: '#222',
+      },
+    },
+    provideHttpClient(withInterceptorsFromDi()),
+    provideAnimations(),
+    {
+      provide: Configuration,
+      useFactory: apiConfigurationFn,
+      deps: [AppConfigService],
+      multi: false,
+    },
+  ],
+}).catch((err) => console.error(err));


### PR DESCRIPTION
Earlier, [scicat-sdk-ts-fetch](https://www.npmjs.com/package/@scicatproject/scicat-sdk-ts-fetch) was used to call scicat-backend, as the angular version was not compatible with [scicat-sdk-ts-angular](https://www.npmjs.com/package/@scicatproject/scicat-sdk-ts-angular). Using it now as it provides a better API (e.g. parameter and return types).