### PR TITLE
fix: initalize touchedAt on logbook creation

### DIFF
--- a/sci-log-db/src/models/logbook.model.ts
+++ b/sci-log-db/src/models/logbook.model.ts
@@ -50,6 +50,7 @@ export class Logbook extends Basesnippet {
   @property({
     type: 'date',
     index: true,
+    defaultFn: 'now',
   })
   touchedAt: Date;
 


### PR DESCRIPTION
Before, newly created had an undefined `touchedAt` timestamp, and were pushed to the end in the UI (as the UI sorts by `touchedAt` by default.
This PR fixes this by initializing `touchedAt` on logbook creation.