### PR TITLE
chore: update prettier commit hash in git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # adds prettier to scilog-fe (i.e. angular) codebase
-734d7eddbae6faa457e734f42f7c76b456c689c5
+94814d508bad92d6df293ec89f79705f768dc618


### PR DESCRIPTION
As the commit hash of prettier refactor changed after merging #464

Tested that after setting
```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```
that the output of `git blame src/app/app.component.ts` and VSCode git blame decoration does not contain the prettier commit.
