### PR TITLE
fix: add properties to eln export required to pass ELN Format tests

### DIFF
--- a/sci-log-db/src/__tests__/unit/service.ro-crate.unit.ts
+++ b/sci-log-db/src/__tests__/unit/service.ro-crate.unit.ts
@@ -78,15 +78,19 @@ describe('ROCrateService (unit)', () => {
     // expect logbook name/description to match
     expect(logbookEntity.name).to.equal('SciLog ELN export: Test Logbook');
     expect(logbookEntity.description).to.equal('A logbook for testing');
-    // expect hasPart to contain two snippets
+    // expect hasPart to contain three snippets: two paragraphs and a comment
     expect(logbookEntity.hasPart).to.be.Array();
-    expect(logbookEntity.hasPart).to.have.length(2);
+    expect(logbookEntity.hasPart).to.have.length(3);
     expect(logbookEntity.hasPart).to.containEql({
       '@id': entityBuilder.getEntityId('snippet-1'),
     });
     expect(logbookEntity.hasPart).to.containEql({
       '@id': entityBuilder.getEntityId('snippet-2'),
     });
+    expect(logbookEntity.hasPart).to.containEql({
+      '@id': entityBuilder.getEntityId('snippet-3'),
+    });
+
     // expect second snippet to have comment as comment
     const snippet2Entity = rocrate.getEntity(
       entityBuilder.getEntityId('snippet-2'),

--- a/sci-log-db/src/services/entity-builder.service.ts
+++ b/sci-log-db/src/services/entity-builder.service.ts
@@ -67,8 +67,25 @@ export class EntityBuilderService {
         fileObj.fileExtension,
       ),
       '@type': 'File',
-      name: fileObj.name,
+      name: fileObj.name ?? `${fileObj._fileId}.${fileObj.fileExtension}`,
       encodingFormat: fileObj.contentType,
+    };
+  }
+
+  buildLicenseEntity() {
+    return {
+      '@id': '#license',
+      '@type': 'CreativeWork',
+      name: 'No license',
+      description: 'This .eln does not contain a license',
+    };
+  }
+
+  buildOrganizationEntity() {
+    return {
+      '@id': 'https://github.com/paulscherrerinstitute/scilog',
+      '@type': 'Organization',
+      name: 'SciLog',
     };
   }
 

--- a/sci-log-db/src/services/ro-crate.service.ts
+++ b/sci-log-db/src/services/ro-crate.service.ts
@@ -60,6 +60,10 @@ export class RoCrateService {
   ): Promise<void> {
     this.crate.root.name = logbook.name;
     this.crate.root.description = logbook.description ?? '';
+    this.crate.root.license = this.entityBuilder.buildLicenseEntity();
+    this.crate.root.datePublished = new Date().toISOString();
+    this.crate.metadata.sdPublisher =
+      this.entityBuilder.buildOrganizationEntity();
     this.crate.root.hasPart = [];
 
     const author = this.entityBuilder.buildPerson(logbook.createdBy);
@@ -99,10 +103,15 @@ export class RoCrateService {
       const parent = this.crate.getEntity(
         this.entityBuilder.getEntityId(paragraph.parentId!),
       );
-      parent.comment ||= [];
-      parent.comment.push(
-        this.entityBuilder.buildCommentEntity(paragraph, author, parent),
+      const commentEntity = this.entityBuilder.buildCommentEntity(
+        paragraph,
+        author,
+        parent,
       );
+      parent.comment ||= [];
+      parent.comment.push(commentEntity);
+      this.logbookEntity.hasPart ||= [];
+      this.logbookEntity.hasPart.push(commentEntity);
     }
 
     await this.handleFiles(paragraph);


### PR DESCRIPTION
This PR fixes some issues with eln export, required to pass tests of TheELNFileFormat:
1. In the SciLog eln export, some entities were missing as per the ROCrate spec (license, datePublished), and sdPublisher as per ELN spec. This PR adds these entities to the metadata node.
2. A `Comment` node is also a dataset. Before, it was only linked to `Paragraph` via the `comment` property. But [roc-validator](https://pypi.org/project/roc-validator/) run as part of ELNFileFormat's CI complains that it should be child of another dataset node - hence, we also add comments as child datasets of the root dataset, along with paragraphs.

TheELNFormat PR: https://github.com/TheELNConsortium/TheELNFileFormat/pull/141