### PR TITLE
build(python): upgrade typeguard dependency

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -2,15 +2,10 @@ from distutils.core import setup
 
 setup(
     name="scilog",
-    version="1.0",
+    version="1.1",
     description="Scilog SDK",
-    author="Klaus Wakonig",
-    author_email="klaus.wakonig@psi.ch",
-    packages=[
-        "scilog",
-    ],
-    install_requires=[
-        "requests >= 2.28.1",
-        "typeguard==2.13.3",
-    ],
+    author="Paul Scherrer Institute, Switzerland",
+    author_email="scilog-help@lists.psi.ch",
+    packages=["scilog"],
+    install_requires=["requests >= 2.28.1", "typeguard~=4.0"],
 )


### PR DESCRIPTION
Minor PR to bump the typeguard dependency to min version 4.0 (released May 2023). I also removed the personal information from the setup file and bumped the scilog version