### PR TITLE
ci: semantic release

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -1,0 +1,45 @@
+name: Semantic Release
+
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+
+permissions:
+    contents: write
+    issues: write
+    pull-requests: write
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Set up Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.11"
+
+            - name: Install semantic-release
+              run: npm install -g semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/exec
+
+            - name: Install Python build tools
+              run: python -m pip install --upgrade pip build twine
+
+            - name: Run semantic-release
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  TWINE_USERNAME: __token__
+                  TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+              run: semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,29 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "echo Releasing ${nextRelease.version} && npm version ${nextRelease.version} --no-git-tag-version --prefix sci-log-db && npm version ${nextRelease.version} --no-git-tag-version --prefix scilog && sed -i -E '/^[[]project[]]$/,/^[[]/{s/^version = \".*\"/version = \"'${nextRelease.version}'\"/}' sdk/python/pyproject.toml",
+        "publishCmd": "python -m build sdk/python --outdir sdk/python/dist && python -m twine upload sdk/python/dist/*"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md",
+          "sci-log-db/package.json",
+          "sci-log-db/package-lock.json",
+          "scilog/package.json",
+          "scilog/package-lock.json",
+          "sdk/python/pyproject.toml"
+        ]
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
Adding the release job with semantic versioning. I do not have enough permission on the repo to add a pypi token so I'd suggest someone else takes over. 

I tested that it properly creates the tag, the changelog file, updates the versions and builds the wheel. 