### PR TITLE
upgrade python version of importTools image to 3.12

### DIFF
--- a/importTools/Dockerfile
+++ b/importTools/Dockerfile
@@ -1,6 +1,6 @@
 # dev image
-FROM python:3.10-slim
-ENV PYTHONDONTWRITEBYTECODE 1
+FROM python:3.12-slim
+ENV PYTHONDONTWRITEBYTECODE=1
 RUN apt-get update && apt-get install -y git
 WORKDIR /usr/src/app
 # copy and install dependencies


### PR DESCRIPTION
the scilog python sdk was updated to >= 3.11
importTools used 3.10, resulting in failed build: https://github.com/paulscherrerinstitute/scilog-ci/pull/146
upgrade to 3.12

tested locally that docker build succeeds