### PR TITLE
Rename RoCrateService to RoCrateExportService

### DIFF
--- a/sci-log-db/src/__tests__/unit/service.ro-crate-export.unit.ts
+++ b/sci-log-db/src/__tests__/unit/service.ro-crate-export.unit.ts
@@ -3,7 +3,7 @@ import {
   expect,
   StubbedInstanceWithSinonAccessor,
 } from '@loopback/testlab';
-import {RoCrateService} from '../../services/ro-crate.service';
+import {RoCrateExportService} from '../../services/ro-crate-export.service';
 import {
   BasesnippetRepository,
   FileRepository,
@@ -14,9 +14,9 @@ import {UserProfile} from '@loopback/security';
 import {LinkType, Logbook, Paragraph} from '../../models';
 import {Filesnippet} from '../../models/file.model';
 
-// these are more like integration tests for RoCrateService + EntityBuilderService
+// these are more like integration tests for RoCrateExportService + EntityBuilderService
 // as EntityBuilderService only contains pure functions, we use the real service instead of mocking their outputs
-describe('ROCrateService (unit)', () => {
+describe('RoCrateExportService (unit)', () => {
   let basesnippetRepository: StubbedInstanceWithSinonAccessor<BasesnippetRepository>;
   let logbookRepository: StubbedInstanceWithSinonAccessor<LogbookRepository>;
   let fileRepository: StubbedInstanceWithSinonAccessor<FileRepository>;
@@ -54,7 +54,7 @@ describe('ROCrateService (unit)', () => {
       }),
     ]);
 
-    const roCrateService = new RoCrateService(
+    const roCrateExportService = new RoCrateExportService(
       user,
       basesnippetRepository,
       logbookRepository,
@@ -62,7 +62,9 @@ describe('ROCrateService (unit)', () => {
       entityBuilder,
     );
 
-    const {rocrate} = await roCrateService.getRoCrateMetadata('logbook-id');
+    const {rocrate} = await roCrateExportService.getRoCrateMetadata(
+      'logbook-id',
+    );
 
     console.log(JSON.stringify(rocrate, null, 2));
     // assert the structure of the ro-crate: root data entity has a logbook,
@@ -122,7 +124,7 @@ describe('ROCrateService (unit)', () => {
       .withArgs('file-2')
       .resolves(givenFilesnippet({_fileId: 'file-2'}));
 
-    const roCrateService = new RoCrateService(
+    const roCrateExportService = new RoCrateExportService(
       user,
       basesnippetRepository,
       logbookRepository,
@@ -130,9 +132,8 @@ describe('ROCrateService (unit)', () => {
       entityBuilder,
     );
 
-    const {rocrate, fileMetadata} = await roCrateService.getRoCrateMetadata(
-      'logbook-id',
-    );
+    const {rocrate, fileMetadata} =
+      await roCrateExportService.getRoCrateMetadata('logbook-id');
 
     expect(fileMetadata).to.containEql({
       snippetId: 'snippet-1',

--- a/sci-log-db/src/controllers/ro-crate.controller.ts
+++ b/sci-log-db/src/controllers/ro-crate.controller.ts
@@ -7,7 +7,7 @@ import {authenticate} from '@loopback/authentication';
 import {authorize} from '@loopback/authorization';
 import {basicAuthorization} from '../services/basic.authorizor';
 import {FileRepository} from '../repositories/file.repository';
-import {RoCrateService} from '../services';
+import {RoCrateExportService} from '../services';
 import {EntityBuilderService} from '../services';
 import {ArchiveService, AssetDescriptor} from '../services/archive.service';
 import {Readable} from 'stream';
@@ -28,7 +28,8 @@ export class RoCrateController {
   static readonly ARCHIVE_ROOT = 'scilog-eln-export';
   constructor(
     @repository(FileRepository) private fileRepository: FileRepository,
-    @service(RoCrateService) private rocrateService: RoCrateService,
+    @service(RoCrateExportService)
+    private rocrateExportService: RoCrateExportService,
     @service(ArchiveService) private archiveService: ArchiveService,
     @service(EntityBuilderService) private entityBuilder: EntityBuilderService,
   ) {}
@@ -44,7 +45,7 @@ export class RoCrateController {
     },
   })
   async findById(@param.path.string('id') id: string): Promise<object> {
-    const {rocrate} = await this.rocrateService.getRoCrateMetadata(id);
+    const {rocrate} = await this.rocrateExportService.getRoCrateMetadata(id);
     return rocrate;
   }
 
@@ -63,7 +64,7 @@ export class RoCrateController {
     @inject(RestBindings.Http.RESPONSE) response: Response,
   ) {
     const {rocrate, fileMetadata} =
-      await this.rocrateService.getRoCrateMetadata(id);
+      await this.rocrateExportService.getRoCrateMetadata(id);
 
     // Build asset descriptors from GridFS streams for files referenced in snippets
     const bucket = new mongodb.GridFSBucket(

--- a/sci-log-db/src/services/index.ts
+++ b/sci-log-db/src/services/index.ts
@@ -4,6 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 export * from './file-upload.service';
-export * from './ro-crate.service';
+export * from './ro-crate-export.service';
 export * from './entity-builder.service';
 export * from './archive.service';

--- a/sci-log-db/src/services/ro-crate-export.service.ts
+++ b/sci-log-db/src/services/ro-crate-export.service.ts
@@ -22,7 +22,7 @@ export interface FileMetadata {
 }
 
 @injectable({scope: BindingScope.TRANSIENT})
-export class RoCrateService {
+export class RoCrateExportService {
   private crate: ROCrate;
   private fileMetadata: FileMetadata[];
   private logbookEntity: RawEntity;


### PR DESCRIPTION
Clarify that the existing RO-Crate service handles export only, in preparation for adding a separate RoCrateImportService.