### PR TITLE
Drop obsolete Compose version key and rename file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,4 @@
-version: "3.9"
+---
 services:
   mongodb:
     image: mongo:4.2


### PR DESCRIPTION
The `version` key in Compose files has been deprecated and is ignored by modern Docker Compose. Renaming to `compose.yaml` makes it the default file picked up by `docker compose` commands, so `-f` is no longer needed when running locally. This aligns the local dev workflow with the README's `docker compose --profile '*' up -d` instruction, which previously required `-f docker-compose.dev.yaml` to actually work.