### PR TITLE
fix(deps): add formidable as direct dependency

### DIFF
--- a/sci-log-db/package-lock.json
+++ b/sci-log-db/package-lock.json
@@ -23,6 +23,7 @@
         "archiver": "^7.0.1",
         "connect-mongo": "^4.6.0",
         "express-session": "^1.17.3",
+        "formidable": "2.1.1",
         "html-to-latex": "^0.8.0",
         "isemail": "^3.2.0",
         "jsdom": "^16.4.0",
@@ -4424,8 +4425,7 @@
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/asn1": {
       "version": "0.2.4",
@@ -5879,7 +5879,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
       "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
-      "dev": true,
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -7273,7 +7272,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
       "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
-      "dev": true,
+      "deprecated": "ACTION REQUIRED: SWITCH TO v3 - v1 and v2 are VULNERABLE! v1 is DEPRECATED FOR OVER 2 YEARS! Use formidable@latest or try formidable-mini for fresh projects",
+      "license": "MIT",
       "dependencies": {
         "dezalgo": "^1.0.4",
         "hexoid": "^1.0.0",
@@ -7841,7 +7841,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
       "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }

--- a/sci-log-db/package.json
+++ b/sci-log-db/package.json
@@ -65,6 +65,7 @@
     "archiver": "^7.0.1",
     "connect-mongo": "^4.6.0",
     "express-session": "^1.17.3",
+    "formidable": "2.1.1",
     "html-to-latex": "^0.8.0",
     "isemail": "^3.2.0",
     "jsdom": "^16.4.0",


### PR DESCRIPTION
formidable is used directly in file.controller.ts for multipart form parsing but was never declared as a dependency in package.json. It only worked by accident because superagent (a transitive dev dependency via @loopback/testlab) pulled it in. Upgrading @loopback/testlab bumps superagent to v10, which depends on formidable v3 — a breaking change that causes "formidable_1.default.IncomingForm is not a constructor" errors. Pinning formidable v2.1.1 as a direct dependency ensures the correct version is installed regardless of transitive dependency changes.