### PR TITLE
feat(tasks): add importance levels feature

### DIFF
--- a/sci-log-db/src/models/basesnippet.model.ts
+++ b/sci-log-db/src/models/basesnippet.model.ts
@@ -147,6 +147,14 @@ export class Basesnippet extends Entity {
     index: true,
   })
   tags?: string[];
+  
+  @property({
+  type: 'number',
+  description: 'Importance level of snippet (1–5)',
+  index: true,
+})
+importance?: number;
+
 
   @property({
     type: 'string',

--- a/scilog/src/app/core/model/config.ts
+++ b/scilog/src/app/core/model/config.ts
@@ -1,31 +1,33 @@
 export interface WidgetConfig {
-  cols: number;
-  rows: number;
-  y: number;
-  x: number;
-  config: WidgetItemConfig;
+    cols: number,
+    rows: number,
+    y: number,
+    x: number,
+    config: WidgetItemConfig
 }
 
 export interface WidgetItemConfig {
-  general: {
-    type?: string;
-    title?: string;
-    readonly?: boolean;
-  };
-  filter: {
-    targetId?: string;
-    additionalLogbooks?: string[];
-    tags?: string[];
-    excludeTags?: string[];
-    ownerGroup?: string;
-    accessGroups?: string[];
-    snippetType?: string[];
-  };
-  view: {
-    order?: string[];
-    hideMetadata?: boolean;
-    showSnippetHeader?: boolean;
-  };
+    general: {
+        type?: string,
+        title?: string,
+        readonly?: boolean
+    },
+    filter: {
+        targetId?: string,
+        additionalLogbooks?: string[],
+        tags?: string[],
+        excludeTags?: string[],
+        ownerGroup?: string,
+        accessGroups?: string[],
+        snippetType?: string[],
+        importance?: number[]
+
+    },
+    view: {
+        order?: string[],
+        hideMetadata?: boolean,
+        showSnippetHeader?: boolean
+    }
 }
 
 // export interface UserConfig {
@@ -35,15 +37,15 @@ export interface WidgetItemConfig {
 // }
 
 export interface CollectionConfig {
-  name: string;
-  description?: string;
-  thumbnail?: string;
-  filter: any;
+    name: string;
+    description?: string;
+    thumbnail?: string;
+    filter: any;
 }
 
 export interface UserPreferences {
-  id?: string;
-  userId?: string;
-  collections?: CollectionConfig[];
-  icon?: string;
+    id?: string;
+    userId?: string;
+    collections?: CollectionConfig[];
+    icon?: string;
 }

--- a/scilog/src/app/core/remote-data.service.ts
+++ b/scilog/src/app/core/remote-data.service.ts
@@ -16,56 +16,39 @@ import _ from 'lodash';
 import { TagsStat } from '@model/tags';
 
 interface Count {
-  count: number;
+  "count": number;
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class RemoteDataService {
-  get imagesLocation() {
-    return `${this.serverSettings.getServerAddress()}/images`;
+
+
+  get imagesLocation () {
+    return `${this.serverSettings.getServerAddress()}/images`
   }
 
-  constructor(
-    protected httpClient: HttpClient,
-    protected serverSettings: ServerSettingsService,
-  ) {}
+  constructor(protected httpClient: HttpClient,
+    protected serverSettings: ServerSettingsService) { }
 
   protected deleteSnippet(snippetPath: string, snippetId: string) {
-    return this.httpClient.delete(
-      this.serverSettings.getServerAddress() + snippetPath + '/' + snippetId,
-    );
+    return this.httpClient.delete(this.serverSettings.getServerAddress() + snippetPath + "/" + snippetId);
   }
 
-  protected patchSnippet<T>(
-    snippetPath: string,
-    snippetId: string,
-    payload: any,
-    headers: HttpHeaders,
-  ) {
-    return this.httpClient.patch<T>(
-      this.serverSettings.getServerAddress() + snippetPath + '/' + snippetId,
-      payload,
-      { headers },
-    );
+  protected patchSnippet<T>(snippetPath: string, snippetId: string, payload: any, headers: HttpHeaders) {
+    return this.httpClient.patch<T>(this.serverSettings.getServerAddress() + snippetPath + "/" + snippetId, payload, { headers });
   }
 
   protected postSnippet<T>(snippetPath: string, payload: any, headers: HttpHeaders) {
-    return this.httpClient.post<T>(this.serverSettings.getServerAddress() + snippetPath, payload, {
-      headers,
-    });
+    return this.httpClient.post<T>(this.serverSettings.getServerAddress() + snippetPath, payload, { headers });
   }
 
   protected uploadFile(formData: any, header: HttpHeaders = null) {
     if (header == null) {
       header = new HttpHeaders().append('accept', 'application/json');
     }
-    return this.httpClient.post(
-      this.serverSettings.getServerAddress() + 'filesnippet/files',
-      formData,
-      { headers: header },
-    );
+    return this.httpClient.post(this.serverSettings.getServerAddress() + "filesnippet/files", formData, { headers: header });
   }
 
   protected getSnippets<T>(snippetPath: string, options: Object) {
@@ -75,11 +58,7 @@ export class RemoteDataService {
   protected async postImage(payloadImage: Images) {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    let data = await this.postSnippet<Images>(
-      'images',
-      JSON.stringify(payloadImage),
-      headers,
-    ).toPromise();
+    let data = await this.postSnippet<Images>("images", JSON.stringify(payloadImage), headers).toPromise();
     return data;
   }
 
@@ -89,54 +68,50 @@ export class RemoteDataService {
     headersFile = headersFile.append('accept', 'application/json');
     formData.append('file', file);
     formData.append('fields', JSON.stringify(payload));
-    return this.postSnippet<Filesnippet>('filesnippet/files', formData, headersFile).toPromise();
+    return this.postSnippet<Filesnippet>("filesnippet/files", formData, headersFile).toPromise();
   }
 
-  protected _prepareParams(
-    config: WidgetItemConfig,
-    index: number = 0,
-    count: number = Infinity,
-  ): HttpParams {
+  protected _prepareParams(config: WidgetItemConfig, index: number = 0, count: number = Infinity): HttpParams {
     let params = new HttpParams();
     params = params.set('filter', JSON.stringify(this._prepareFilters(config, index, count)));
     return params;
   }
 
-  protected _prepareFilters(
-    config: WidgetItemConfig,
-    index: number = 0,
-    count: number = Infinity,
-  ): Object {
+  protected _prepareFilters(config: WidgetItemConfig, index: number = 0, count: number = Infinity): Object {
     let httpFilter: Object = {};
     if (typeof config.view.order != 'undefined') {
-      httpFilter['order'] = config.view.order;
+      httpFilter["order"] = config.view.order;
     } else {
-      httpFilter['order'] = ['defaultOrder ASC'];
+      httpFilter["order"] = ["defaultOrder DESC"];
     }
 
-    httpFilter['include'] = [{ relation: 'subsnippets', ...this.addIncludeScope(config.filter) }];
-    httpFilter['where'] = {
-      and: [
-        ...this.staticFilters(),
-        ...this.tagsFilter(config.filter),
-        ...this.parentFilter(config.filter),
-      ],
-    };
+    httpFilter["include"] = [{ relation: "subsnippets", ...this.addIncludeScope(config.filter) }];
+
+
+httpFilter["where"] = {
+  "and": [
+    ...this.staticFilters(),
+    ...this.tagsFilter(config.filter),
+    ...this.parentFilter(config.filter),
+    ...this.importanceFilter(config.filter) 
+  ]
+};
+
 
     if (count < Infinity) {
-      httpFilter['limit'] = count;
+      httpFilter["limit"] = count;
     }
     if (index > 0) {
-      httpFilter['skip'] = index;
+      httpFilter["skip"] = index;
     }
     return httpFilter;
   }
 
   private staticFilters() {
-    return [{ snippetType: { inq: ['paragraph', 'image'] } }, { deleted: false }];
+    return [{ snippetType: { inq: ["paragraph", "image"] } }, { deleted: false }];
   }
 
-  protected tagsFilter(configFilter: { tags?: string[]; excludeTags?: string[] }) {
+  protected tagsFilter(configFilter: { tags?: string[], excludeTags?: string[] }) {
     const tagFilter = [];
     if (configFilter?.tags?.length > 0) {
       tagFilter.push({ tags: { inq: configFilter.tags } });
@@ -146,27 +121,34 @@ export class RemoteDataService {
     }
     return tagFilter;
   }
+protected importanceFilter(configFilter: { importance?: number[] }){
+ if (!configFilter?.importance || configFilter.importance.length === 0) {
+  return [];
+}
 
-  private parentFilter(configFilter: { targetId?: string; additionalLogbooks?: string[] }) {
-    const parentIds = [configFilter?.targetId, ...(configFilter?.additionalLogbooks ?? [])].filter(
-      (parentId) => parentId,
-    );
+return [{
+  importance: { inq: configFilter.importance }
+}];
+}
+
+
+  private parentFilter(configFilter: { targetId?: string, additionalLogbooks?: string[] }) {
+    const parentIds = [configFilter?.targetId, ...(configFilter?.additionalLogbooks ?? [])].filter(parentId => parentId);
     if (parentIds.length === 0) return [];
     return [{ parentId: { inq: parentIds } }];
   }
 
-  protected addIncludeScope(configFilter?: { tags?: string[]; excludeTags?: string[] }): object {
+  protected addIncludeScope(configFilter?: { tags?: string[], excludeTags?: string[] }): object {
     return {
-      scope: {
-        include: [
-          {
-            relation: 'subsnippets',
-            scope: {
-              where: { snippetType: 'edit' },
-            },
-          },
-        ],
-      },
+      scope:
+      {
+        include: [{
+          relation: 'subsnippets',
+          scope: {
+            where: { snippetType: 'edit' }
+          }
+        }]
+      }
     };
   }
 
@@ -174,16 +156,18 @@ export class RemoteDataService {
     let filter = this._prepareFilters(config);
     console.log(filter);
     let params = new HttpParams();
-    params = params.set('where', JSON.stringify(filter['where']));
-    return this.getSnippets<Count>('basesnippets/count', { params: params }).toPromise();
+    params = params.set('where', JSON.stringify(filter["where"]));
+    return this.getSnippets<Count>('basesnippets/count', { params: params }).toPromise()
   }
+
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class LogbookItemDataService extends RemoteDataService {
-  private _searchString = '';
+
+  private _searchString = "";
 
   public get searchString(): string {
     return this._searchString;
@@ -193,29 +177,25 @@ export class LogbookItemDataService extends RemoteDataService {
   }
 
   getDataBuffer(index: number, count: number, config: WidgetItemConfig) {
-    console.log(index, count);
+    console.log(index, count)
 
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
     this._searchString = this._searchString.trim();
     if (this._searchString.length == 0) {
-      return this.getSnippets<any[]>('basesnippets', {
-        headers: headers,
-        params: this._prepareParams(config, index, count),
-      }).toPromise();
+      return this.getSnippets<any[]>('basesnippets', { headers: headers, params: this._prepareParams(config, index, count) }).toPromise();
     } else {
-      return this.getSnippets<any[]>('basesnippets/search=' + this._searchString, {
-        headers: headers,
-        params: this._prepareParams(config, index, count),
-      }).toPromise();
+      return this.getSnippets<any[]>('basesnippets/search=' + this._searchString, { headers: headers, params: this._prepareParams(config, index, count) }).toPromise();
     }
+
   }
 
-  protected addIncludeScope(configFilter: { tags?: string[]; excludeTags?: string[] }): Object {
-    const scope = super.addIncludeScope() as { scope: { where?: {} } };
+  protected addIncludeScope(configFilter: { tags?: string[], excludeTags?: string[] }): Object {
+    const scope = super.addIncludeScope() as {scope: {where?: {}}};
     const tags = this.tagsFilter(configFilter);
-    if (tags.length === 0) return scope;
-    scope.scope.where = { or: [{ snippetType: 'edit' }, { and: tags }] };
+    if (tags.length === 0)
+      return scope;
+    scope.scope.where = {or: [{snippetType: 'edit'}, {and: tags}]}
     return scope;
   }
 
@@ -229,7 +209,7 @@ export class LogbookItemDataService extends RemoteDataService {
     // console.log(fileSnippet)
     // let headers = new HttpHeaders();
     // headers = headers.set('Accept', 'application/json');
-    return this.getSnippets<Blob>('images/' + id, { responseType: 'blob' }).toPromise();
+    return this.getSnippets<Blob>("images/" + id, { responseType: 'blob' }).toPromise();
   }
 
   getFilesnippet(id: string) {
@@ -243,22 +223,19 @@ export class LogbookItemDataService extends RemoteDataService {
     // let payload: ChangeStreamNotification = {
     //   tags: ["_delete_" + snippetId]
     // };
-    return this.deleteSnippet('basesnippets', snippetId).toPromise();
+    return this.deleteSnippet("basesnippets", snippetId).toPromise();
   }
 
   getBasesnippet(id: string) {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
     let httpFilter: Object = {};
-    httpFilter['include'] = [{ relation: 'subsnippets' }];
+    httpFilter["include"] = [{ "relation": "subsnippets" }];
 
     let params = new HttpParams();
     params = params.set('filter', JSON.stringify(httpFilter));
 
-    return this.getSnippets<Basesnippets>('basesnippets/' + id, {
-      headers: headers,
-      params: params,
-    }).toPromise();
+    return this.getSnippets<Basesnippets>('basesnippets/' + id, { headers: headers, params: params }).toPromise();
   }
 
   async getIndex(id: string, config: any) {
@@ -266,36 +243,28 @@ export class LogbookItemDataService extends RemoteDataService {
     console.log(filter);
     let params = new HttpParams();
     params = params.set('filter', JSON.stringify(filter));
-    return this.getSnippets<number>('basesnippets/index=' + id, { params: params }).toPromise();
+    return this.getSnippets<number>('basesnippets/index=' + id, { params: params }).toPromise()
   }
 
-  private async _uploadImageFile(
-    payload: ChangeStreamNotification,
-  ): Promise<ChangeStreamNotification> {
+  private async _uploadImageFile(payload: ChangeStreamNotification): Promise<ChangeStreamNotification> {
     if (payload.files) {
       console.log(payload);
-      await Promise.all(
-        payload.files.map(async (file) => {
-          if (file.file) {
-            // first upload filesnippet then set file id for basesnippet
-            // let imgPayload: Images = _.pick(payload, ['ownerGroup', 'accessGroups', 'isPrivate']);
-            let filePayload: Filesnippet = _.pick(payload, [
-              'ownerGroup',
-              'accessGroups',
-              'isPrivate',
-            ]);
-            filePayload.fileExtension = file.fileExtension.split('/')[1];
-            let dataFile = await this.postFilesnippet(filePayload, file.file);
-            console.log(filePayload);
-            delete file.file;
+      await Promise.all(payload.files.map(async file => {
+        if (file.file) {
+          // first upload filesnippet then set file id for basesnippet
+          // let imgPayload: Images = _.pick(payload, ['ownerGroup', 'accessGroups', 'isPrivate']);
+          let filePayload: Filesnippet = _.pick(payload, ['ownerGroup', 'accessGroups', 'isPrivate']);
+          filePayload.fileExtension = file.fileExtension.split("/")[1];
+          let dataFile = await this.postFilesnippet(filePayload, file.file);
+          console.log(filePayload)
+          delete file.file;
 
-            console.log(file);
+          console.log(file);
 
-            file.fileId = dataFile.id;
-            file.accessHash = dataFile.accessHash; // TODO: remove this static assignment and instead retrieve the accessHash dynamically
-          }
-        }),
-      );
+          file.fileId = dataFile.id;
+          file.accessHash = dataFile.accessHash // TODO: remove this static assignment and instead retrieve the accessHash dynamically
+        }
+      }))
     }
     console.log(payload);
     return payload;
@@ -304,70 +273,51 @@ export class LogbookItemDataService extends RemoteDataService {
   async uploadParagraph(payload: ChangeStreamNotification, id?: string) {
     // let files: FilesSnippet[] = [];
     let subsnippet: ChangeStreamNotification = null;
-    if (payload?.subsnippets && payload.subsnippets.length > 0) {
+    if ((payload?.subsnippets) && (payload.subsnippets.length > 0)) {
       subsnippet = JSON.parse(JSON.stringify(payload.subsnippets[0]));
     }
     delete payload.subsnippets;
 
     if (id) {
       // patch existing snippet
-      console.log('PATCH', payload);
+      console.log("PATCH", payload)
       payload = await this._uploadImageFile(payload);
 
       let headers = new HttpHeaders();
       headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-      await this.patchSnippet('basesnippets', id, JSON.stringify(payload), headers).toPromise();
+      await this.patchSnippet("basesnippets", id, JSON.stringify(payload), headers).toPromise();
     } else {
       payload = await this._uploadImageFile(payload);
 
       let headers = new HttpHeaders();
       headers = headers.set('Content-Type', 'application/json; charset=utf-8');
       console.log(payload);
-      let data = await this.postSnippet<Basesnippets>(
-        'basesnippets',
-        JSON.stringify(payload),
-        headers,
-      ).toPromise();
+      let data = await this.postSnippet<Basesnippets>("basesnippets", JSON.stringify(payload), headers).toPromise();
       if (subsnippet != null) {
         subsnippet.parentId = data.id;
         subsnippet.linkType = LinkType.QUOTE;
-        await this.postSnippet<Basesnippets>(
-          'basesnippets',
-          JSON.stringify(subsnippet),
-          headers,
-        ).toPromise();
+        await this.postSnippet<Basesnippets>("basesnippets", JSON.stringify(subsnippet), headers).toPromise();
       }
     }
   }
 
   deleteAllInProgressEditing(editId: string): void {
-    this.deleteSnippet('edits/paragraphs-to-delete', editId).toPromise();
+    this.deleteSnippet("edits/paragraphs-to-delete", editId).toPromise();
   }
 
   exportLogbook(exportType: string, config: any, skip: number, limit: number): Promise<Blob> {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json');
-    return this.getSnippets<Blob>('basesnippets/export=' + exportType + '', {
-      headers: headers,
-      responseType: 'blob',
-      params: this._prepareParams(config, skip, limit),
-    }).toPromise();
-  }
-
-  exportELN(logbookId: string): Promise<Blob> {
-    return this.httpClient
-      .get(`${this.serverSettings.getServerAddress()}rocrates/${logbookId}/download`, {
-        responseType: 'blob',
-      })
-      .toPromise();
+    return this.getSnippets<Blob>("basesnippets/export=" + exportType + "", { headers: headers, responseType: 'blob', params: this._prepareParams(config, skip, limit) }).toPromise();
   }
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class LogbookDataService extends RemoteDataService {
-  private _searchString = '';
+
+  private _searchString = "";
 
   public get searchString(): string {
     return this._searchString;
@@ -377,28 +327,17 @@ export class LogbookDataService extends RemoteDataService {
   }
 
   deleteLogbook(logbookId: string): Promise<any> {
-    return this.deleteSnippet('logbooks', logbookId).toPromise();
+    return this.deleteSnippet("logbooks", logbookId).toPromise();
   }
 
   patchLogbook(logbookId: string, payload: any): Promise<Logbooks> {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
-    return this.patchSnippet<Logbooks>(
-      'logbooks',
-      logbookId,
-      JSON.stringify(payload),
-      headers,
-    ).toPromise();
+    return this.patchSnippet<Logbooks>('logbooks', logbookId, JSON.stringify(payload), headers).toPromise();
   }
 
   touchLogbook(logbookId: string): Promise<void> {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
-    return this.httpClient
-      .patch<void>(
-        this.serverSettings.getServerAddress() + 'logbooks/' + logbookId + '/touch',
-        {},
-        { headers },
-      )
-      .toPromise();
+    return this.httpClient.patch<void>(this.serverSettings.getServerAddress() + 'logbooks/' + logbookId + '/touch', {}, { headers }).toPromise();
   }
 
   postLogbook(payload: any): Promise<Logbooks> {
@@ -413,18 +352,15 @@ export class LogbookDataService extends RemoteDataService {
   getLocations() {
     let params = new HttpParams();
     let httpFilter: Object = {};
-    httpFilter['order'] = ['defaultOrder ASC'];
-    httpFilter['where'] = { snippetType: 'location', location: 'root' };
-    httpFilter['include'] = [{ relation: 'subsnippets' }];
+    httpFilter["order"] = ["defaultOrder ASC"];
+    httpFilter["where"] = { "snippetType": "location", "location": "root" };
+    httpFilter["include"] = [{ "relation": "subsnippets" }];
     // console.log(JSON.stringify(httpFilter));
     params = params.set('filter', JSON.stringify(httpFilter));
     // console.log(params);
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.getSnippets<Basesnippets[]>('basesnippets', {
-      headers: headers,
-      params: params,
-    }).toPromise();
+    return this.getSnippets<Basesnippets[]>('basesnippets', { headers: headers, params: params }).toPromise();
   }
 
   _getLogbookInfo(id: string): Promise<Logbooks> {
@@ -442,11 +378,8 @@ export class LogbookDataService extends RemoteDataService {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
     let params = new HttpParams();
-    params = params.set('filter', JSON.stringify({ where: { id: { inq: ids } } }));
-    return this.getSnippets<Logbooks[]>('logbooks', {
-      headers: headers,
-      params: params,
-    }).toPromise();
+    params = params.set('filter', JSON.stringify({where: {id: {inq: ids}}}));
+    return this.getSnippets<Logbooks[]>('logbooks', { headers: headers, params: params }).toPromise();
   }
 
   _getAvailLogbooks(): Promise<Logbooks[]> {
@@ -456,145 +389,129 @@ export class LogbookDataService extends RemoteDataService {
   }
 
   getDataBuffer(index: number, count: number, config: WidgetItemConfig) {
-    console.log(index, count);
+    console.log(index, count)
 
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
     this._searchString = this._searchString.trim();
 
     let httpFilter: Object = this._prepareFilters(config, index, count);
+    console.log("FINAL WHERE:", httpFilter["where"]);
+
     let params = new HttpParams();
-    params = params.set('filter', JSON.stringify(httpFilter));
+    params = params.set('filter', JSON.stringify(httpFilter))
 
     if (this._searchString.length == 0) {
-      return this.getSnippets<any[]>('basesnippets', {
-        headers: headers,
-        params: params,
-      }).toPromise();
+      return this.getSnippets<any[]>('basesnippets', { headers: headers, params: params }).toPromise();
     } else {
-      return this.getSnippets<any[]>('basesnippets/search=' + this._searchString, {
-        headers: headers,
-        params: params,
-      }).toPromise();
+      return this.getSnippets<any[]>('basesnippets/search=' + this._searchString, { headers: headers, params: params }).toPromise();
     }
   }
 
-  protected _prepareFilters(
-    config: WidgetItemConfig,
-    index: number = 0,
-    count: number = Infinity,
-  ): Object {
+  protected _prepareFilters(config: WidgetItemConfig, index: number = 0, count: number = Infinity): Object {
+    
     let httpFilter: Object = {};
-    httpFilter['order'] = config.view.order ?? ['defaultOrder DESC'];
+    httpFilter["order"] = config.view.order ?? ["defaultOrder DESC"];
 
     let whereFilter: Object[] = [];
-    whereFilter.push({ snippetType: 'logbook', deleted: false });
+    whereFilter.push({ "snippetType": "logbook", deleted: false });
 
-    httpFilter['where'] = { and: whereFilter };
+    httpFilter["where"] = { "and": whereFilter };
 
     if (count < Infinity) {
-      httpFilter['limit'] = count;
+      httpFilter["limit"] = count;
     }
     if (index > 0) {
-      httpFilter['skip'] = index;
+      httpFilter["skip"] = index;
     }
 
     if (this._searchString.length > 0) {
-      httpFilter['include'] = [{ relation: 'subsnippets' }];
+      httpFilter["include"] = [{ "relation": "subsnippets" }];
     }
     return httpFilter;
   }
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class WidgetPreferencesDataService extends RemoteDataService {
+
   getSnippetsForLogbook(logbookId: string): Promise<Basesnippets[]> {
     let params = new HttpParams();
     let httpFilter: Object = {};
-    httpFilter['where'] = { parentId: logbookId };
+    httpFilter["where"] = { "parentId": logbookId };
     params = params.set('filter', JSON.stringify(httpFilter));
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.getSnippets<Basesnippets[]>('basesnippets', {
-      headers: headers,
-      params: params,
-    }).toPromise();
+    return this.getSnippets<Basesnippets[]>('basesnippets', { headers: headers, params: params }).toPromise();
   }
 
   getPlotSnippets(logbookId: string): Promise<Basesnippets[]> {
     let params = new HttpParams();
     let httpFilter: Object = {};
-    httpFilter['where'] = { parentId: logbookId, snippetType: 'plot' };
+    httpFilter["where"] = { "parentId": logbookId, "snippetType": "plot" };
     params = params.set('filter', JSON.stringify(httpFilter));
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.getSnippets<Basesnippets[]>('basesnippets', {
-      headers: headers,
-      params: params,
-    }).toPromise();
+    return this.getSnippets<Basesnippets[]>('basesnippets', { headers: headers, params: params }).toPromise();
   }
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class SnippetViewerDataService extends RemoteDataService {
   getSnippetViewerData(snippetId: string): Promise<Basesnippets[]> {
     let params = new HttpParams();
     let httpFilter: Object = {};
-    httpFilter['where'] = { id: snippetId };
+    httpFilter["where"] = { "id": snippetId };
     params = params.set('filter', JSON.stringify(httpFilter));
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.getSnippets<Basesnippets[]>('basesnippets', {
-      headers: headers,
-      params: params,
-    }).toPromise();
+    return this.getSnippets<Basesnippets[]>('basesnippets', { headers: headers, params: params }).toPromise();
   }
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class PlotDataService extends RemoteDataService {
   getPlotSnippets(snippetId: string): Promise<Basesnippets[]> {
     let params = new HttpParams();
     let httpFilter: Object = {};
-    httpFilter['where'] = { id: snippetId };
+    httpFilter["where"] = { "id": snippetId };
     params = params.set('filter', JSON.stringify(httpFilter));
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.getSnippets<Basesnippets[]>('basesnippets', {
-      headers: headers,
-      params: params,
-    }).toPromise();
+    return this.getSnippets<Basesnippets[]>("basesnippets", { headers: headers, params: params }).toPromise();
   }
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class AuthDataService extends RemoteDataService {
   login(principal: string, password: string) {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    return this.postSnippet<User>('users/login', { principal, password }, headers);
+    return this.postSnippet<User>('users/login', { principal, password }, headers)
   }
 }
 
+
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class TaskDataService extends RemoteDataService {
+
   getTasksData(id: string): Promise<Tasks[]> {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
     let httpFilter: Object = {};
-    httpFilter['where'] = { parentId: id };
+    httpFilter["where"] = { "parentId": id };
     let params = new HttpParams();
     params = params.set('filter', JSON.stringify(httpFilter));
-    return this.getSnippets<Tasks[]>('tasks', { headers: headers, params: params }).toPromise();
+    return this.getSnippets<Tasks[]>("tasks", { headers: headers, params: params }).toPromise();
   }
 
   addTask(task: Tasks): Promise<any> {
@@ -613,47 +530,41 @@ export class TaskDataService extends RemoteDataService {
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class TagDataService extends RemoteDataService {
   private isValidTag(tag: string) {
-    if (tag.includes('_delete_')) {
+    if (tag.includes("_delete_")) {
       return false;
     }
     return true;
   }
   async getTags(id: string): Promise<TagsStat[]> {
     let httpFilter: Object = {};
-    httpFilter['where'] = { parentId: id };
-    httpFilter['fields'] = { tags: true };
+    httpFilter["where"] = { "parentId": id };
+    httpFilter["fields"] = { "tags": true };
     let params = new HttpParams();
     params = params.set('filter', JSON.stringify(httpFilter));
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
-    let data = await this.getSnippets<Basesnippets[]>('basesnippets/', {
-      headers: headers,
-      params: params,
-    }).toPromise();
-    let tags = _.compact(
-      data.map((x) => {
-        if (x.tags && x.tags.length > 0) {
-          return x.tags.filter((tag) => {
-            return this.isValidTag(tag);
-          });
-        } else {
-          return null;
-        }
-      }),
-    );
+    let data = await this.getSnippets<Basesnippets[]>("basesnippets/", { headers: headers, params: params }).toPromise();
+    let tags = _.compact(data.map(x => {
+      if ((x.tags) && (x.tags.length > 0)) {
+        return x.tags.filter(tag => { return this.isValidTag(tag) });
+      } else {
+        return null;
+      }
+    }));
 
     let res: TagsStat[] = [];
 
-    tags.forEach((snippet) => {
-      snippet.forEach((tag) => {
-        let entry = res.find((e) => e.name == tag);
-        typeof entry == 'undefined' ? res.push({ name: tag, count: 1 }) : (entry.count += 1);
-      });
-    });
+    tags.forEach(snippet => {
+      snippet.forEach(tag => {
+        let entry = res.find(e => e.name == tag);
+        typeof entry == 'undefined' ? res.push({ name: tag, count: 1 }) : entry.count += 1;
+      })
+    })
     return _.orderBy(res, ['count'], ['desc']);
+
   }
   getLastEntry(config: WidgetItemConfig) {
     let headers = new HttpHeaders();
@@ -661,23 +572,22 @@ export class TagDataService extends RemoteDataService {
     console.log(config);
     let _config = JSON.parse(JSON.stringify(config));
     if (typeof _config.view.order != 'undefined') {
-      let order = _config.view.order[0].split(' ');
-      _config.view.order = order[0] + ' DESC';
+      let order = _config.view.order[0].split(" ");
+      _config.view.order = order[0] + " DESC";
     } else {
-      _config.view.order = ['defaultOrder DESC'];
+      _config.view.order = ["defaultOrder DESC"];
     }
     console.log(_config);
-    return this.getSnippets<any[]>('basesnippets', {
-      headers: headers,
-      params: this._prepareParams(_config, 0, 1),
-    }).toPromise();
+    return this.getSnippets<any[]>('basesnippets', { headers: headers, params: this._prepareParams(_config, 0, 1) }).toPromise();
   }
 }
 
+
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class UserPreferencesDataService extends RemoteDataService {
+
   getUserPreferences() {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
     return this.getSnippets<UserPreferences[]>('user-preferences', { headers: headers });
@@ -696,26 +606,28 @@ export class UserPreferencesDataService extends RemoteDataService {
   deleteUserPreferences(id: string): Promise<any> {
     return this.deleteSnippet('user-preferences', id).toPromise();
   }
+
 }
 
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class ViewDataService extends RemoteDataService {
+
   getViews(id: string): Promise<Views[]> {
     let params = new HttpParams();
     let httpFilter: Object = {};
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
-    httpFilter['where'] = { parentId: id };
+    httpFilter["where"] = { "parentId": id };
     params = params.set('filter', JSON.stringify(httpFilter));
-    return this.getSnippets<Views[]>('views', { headers: headers, params: params }).toPromise();
+    return this.getSnippets<Views[]>("views", { headers: headers, params: params }).toPromise();
   }
 
   postView(payload: any): Promise<Views> {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json');
-    return this.postSnippet<Views>('views', JSON.stringify(payload), headers).toPromise();
+    return this.postSnippet<Views>("views", JSON.stringify(payload), headers).toPromise();
   }
 
   patchView(payload: any, id: string): Promise<Views> {
@@ -723,13 +635,16 @@ export class ViewDataService extends RemoteDataService {
     headers = headers.set('Content-Type', 'application/json');
     return this.patchSnippet<Views>('views', id, JSON.stringify(payload), headers).toPromise();
   }
+
 }
 
+
 @Injectable({
-  providedIn: 'root',
+  providedIn: 'root'
 })
 export class SearchDataService extends RemoteDataService {
-  private _searchString = '';
+
+  private _searchString = "";
 
   public get searchString(): string {
     return this._searchString;
@@ -743,21 +658,17 @@ export class SearchDataService extends RemoteDataService {
   }
 
   getDataBuffer(index: number, count: number, config: WidgetItemConfig) {
-    console.log(index, count);
+    console.log(index, count)
 
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/json; charset=utf-8');
     this._searchString = this._searchString.trim();
     if (this._searchString.length == 0) {
-      return this.getSnippets<any[]>('basesnippets', {
-        headers: headers,
-        params: this._prepareParams(config, index, count),
-      }).toPromise();
+      return this.getSnippets<any[]>('basesnippets', { headers: headers, params: this._prepareParams(config, index, count) }).toPromise();
     } else {
-      return this.getSnippets<any[]>(
-        `basesnippets/search=${encodeURIComponent(this._searchString)}`,
-        { headers: headers, params: this._prepareParams(config, index, count) },
-      ).toPromise();
+      return this.getSnippets<any[]>(`basesnippets/search=${encodeURIComponent(this._searchString)}`, { headers: headers, params: this._prepareParams(config, index, count) }).toPromise();
     }
+
   }
+
 }

--- a/scilog/src/app/logbook/core/changestreamnotification.model.ts
+++ b/scilog/src/app/logbook/core/changestreamnotification.model.ts
@@ -1,7 +1,8 @@
 import { Basesnippets } from '@model/basesnippets';
 
-export interface ChangeStreamNotification extends Basesnippets {
-  operationType?: string;
-  content?: any;
-  [key: string]: any;
+export interface ChangeStreamNotification extends Basesnippets{
+    operationType?: string;
+    content?: any;
+    [key: string]: any;
+    importance?: number; 
 }

--- a/scilog/src/app/logbook/widgets/logbook-item/logbook-item.component.html
+++ b/scilog/src/app/logbook/widgets/logbook-item/logbook-item.component.html
@@ -18,138 +18,84 @@
   </mat-form-field> -->
   <div #snippetContainer class="logbook-content">
     <div *uiScroll="let snippet of logbookScrollService.datasource; let i = index">
-      <app-snippet
-        [snippet]="snippet"
-        [updatedAt]="snippet.updatedAt"
-        [index]="i + 1"
-        [config]="config"
-        [indexOrdered]="_indexOrder(i)"
-        (isLoading)="logbookScrollService.setItemStatus(snippet.id, $event)"
-      >
+      <app-snippet [snippet]="snippet" [updatedAt]="snippet.updatedAt" [index]=i+1 [config]="config" [indexOrdered]="_indexOrder(i)" (isLoading)="logbookScrollService.setItemStatus(snippet.id, $event)">
       </app-snippet>
     </div>
   </div>
 
-  <button
-    mat-mini-fab
-    class="float"
-    (click)="scrollOnClickTo('end')"
-    [@scrollButton]
-    *ngIf="!isAt('end') && !isDescending"
-  >
+  <button mat-mini-fab class="float" (click)="scrollOnClickTo('end')" [@scrollButton] *ngIf="!isAt('end') && !isDescending">
     <mat-icon>keyboard_double_arrow_down</mat-icon>
   </button>
-  <button
-    mat-mini-fab
-    class="float"
-    (click)="scrollOnClickTo('start')"
-    [@scrollButton]
-    *ngIf="!isAt('start') && isDescending"
-  >
+  <button mat-mini-fab class="float" (click)="scrollOnClickTo('start')" [@scrollButton] *ngIf="!isAt('start') && isDescending">
     <mat-icon>keyboard_double_arrow_up</mat-icon>
   </button>
-  <div
-    *ngIf="!mobile && !isReadOnly"
-    [ngClass]="isLightMode ? 'editor-container' : 'editor-container-no-border'"
-  >
-    <div
-      #editor
-      class="content-editor"
-      [ngStyle]="{
-        'padding-left': dashboardView === true ? '0px' : '78px',
-        width: dashboardView === true ? '97%' : '92%',
-      }"
-      (appResized)="onResized()"
-    >
-      <div class="accessSettings">
-        <span [ngStyle]="{ flex: '1 1 auto' }"></span>
+  <div *ngIf="!mobile && !isReadOnly" [ngClass]="isLightMode ? 'editor-container' : 'editor-container-no-border'">
+    <div #editor class="content-editor"
+      [ngStyle]="{'padding-left':dashboardView === true ? '0px' : '78px', 'width': dashboardView === true ? '97%' : '92%'}"
+      (appResized)="onResized()">
+      <div class='accessSettings'>
+        <span [ngStyle]="{'flex':'1 1 auto'}"></span>
         <span matTooltip="ownerGroup">
-          <span [ngStyle]="{ 'vertical-align': 'middle' }">
-            <mat-icon [inline]="true">person</mat-icon>
+          <span [ngStyle]="{'vertical-align':'middle'}">
+            <mat-icon [inline]='true'>person</mat-icon>
           </span>
-          <span>{{ logbookInfo.logbookInfo.ownerGroup }}</span>
+          <span>{{ logbookInfo.logbookInfo.ownerGroup}}</span>
         </span>
-        <span *ngIf="logbookInfo.logbookInfo.accessGroups.length > 0" matTooltip="accessGroups">
+        <span *ngIf='logbookInfo.logbookInfo.accessGroups.length>0' matTooltip='accessGroups'>
           <span> / </span>
-          <span [ngStyle]="{ 'vertical-align': 'middle' }">
-            <mat-icon [inline]="true">group</mat-icon>
+          <span [ngStyle]="{'vertical-align':'middle'}">
+            <mat-icon [inline]='true'>group</mat-icon>
           </span>
-          <span> {{ logbookInfo.logbookInfo.accessGroups }}</span>
+          <span> {{ logbookInfo.logbookInfo.accessGroups}}</span>
         </span>
       </div>
-      <ckeditor
-        #contentEditor
-        [config]="editorConfig"
-        [editor]="Editor"
-        [data]="dataEditor"
-        (ready)="onEditorReady($event)"
-      ></ckeditor>
-      <div class="tagsContainer">
-        <span class="tagEditor">
-          <app-tag-editor
-            [ngStyle]="{ width: '100%' }"
-            #tagEditor
-            [tagIn]="tag"
-            [configIndex]="configIndex"
-          ></app-tag-editor>
-        </span>
-        <span class="addButton">
-          <button mat-mini-fab (click)="addContent()" matTooltip="Send">
-            <mat-icon>send</mat-icon>
-          </button>
-          <button
-            mat-mini-fab
-            (click)="addMessage()"
-            *ngIf="messagesEnabled"
-            matTooltip="Send as message"
-          >
-            <mat-icon>message</mat-icon>
-          </button>
-        </span>
+      <div class="importance-section">
+        <span><strong>Importance:</strong></span>
+
+        <mat-radio-group [(ngModel)]="importance">
+          <mat-radio-button *ngFor="let level of importanceLevels" [value]="level">
+            {{ level }}
+          </mat-radio-button>
+        </mat-radio-group>
       </div>
+
+      <ckeditor #contentEditor [config]="editorConfig" [editor]="Editor" [data]="dataEditor"
+        (ready)="onEditorReady($event)"></ckeditor>
+        <div class='tagsContainer'>
+          <span class='tagEditor'>
+            <app-tag-editor [ngStyle]="{'width': '100%'}" #tagEditor [tagIn]="tag" [configIndex]="configIndex"></app-tag-editor>
+          </span>
+            <span class="addButton">
+              <button mat-mini-fab (click)="addContent()" matTooltip="Send">
+                <mat-icon>send</mat-icon>
+              </button>
+              <button mat-mini-fab (click)="addMessage()" *ngIf="messagesEnabled" matTooltip="Send as message">
+                <mat-icon>message</mat-icon>
+              </button>
+          </span>
+        </div>
+
     </div>
+
   </div>
+
 </div>
 <ng-container *ngIf="mobile && !isReadOnly">
-  <button
-    mat-fab
-    color="accent"
-    aria-label="Add snippet"
-    class="mat-fab-bottom-right"
-    (click)="toggle()"
-    [@rotatedState]="isOpen ? 'rotated' : 'default'"
-    (focusout)="closeToolSelection()"
-    style="z-index: 1001"
-  >
+  <button mat-fab color="accent" aria-label="Add snippet" class="mat-fab-bottom-right" (click)="toggle()"
+    [@rotatedState]="isOpen ? 'rotated' : 'default'" (focusout)="closeToolSelection()" style="z-index: 1001;">
     <mat-icon>add</mat-icon>
   </button>
-  <button
-    #editButton
-    mat-fab
-    color="accent"
-    aria-label="Edit"
-    class="mat-fab-bottom-right"
-    [@buttonEdit]="isOpen ? 'end' : 'start'"
-    (click)="addSnippet($event)"
-    style="z-index: 1000"
-  >
+  <button #editButton mat-fab color="accent" aria-label="Edit" class="mat-fab-bottom-right"
+    [@buttonEdit]="isOpen ? 'end' : 'start'" (click)="addSnippet($event)" style="z-index: 1000;">
     <mat-icon>edit</mat-icon>
   </button>
   <!-- <button #taskButton mat-fab color="accent" aria-label="Edit" class="mat-fab-bottom-right"
     [@buttonTask]="isOpen ? 'end' : 'start'" (click)="addSnippet($event)" style="z-index: 1000;">
     <mat-icon>add_task</mat-icon>
   </button> -->
-  <input style="display: none" type="file" (change)="onFileChanged($event)" #fileInput />
-  <button
-    #photoButton
-    mat-fab
-    color="accent"
-    aria-label="Photo"
-    class="mat-fab-bottom-right"
-    [@buttonPhoto]="isOpen ? 'end' : 'start'"
-    (click)="fileInput.click()"
-    style="z-index: 1000"
-  >
+  <input style="display: none" type="file" (change)="onFileChanged($event)" #fileInput>
+  <button #photoButton mat-fab color="accent" aria-label="Photo" class="mat-fab-bottom-right"
+    [@buttonPhoto]="isOpen ? 'end' : 'start'" (click)="fileInput.click()" style="z-index: 1000;">
     <mat-icon>add_a_photo</mat-icon>
   </button>
   <!-- <button #fileButton mat-fab color="accent" aria-label="File" class="mat-fab-bottom-right"

--- a/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.html
+++ b/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.html
@@ -1,251 +1,200 @@
 <div mat-dialog-title>
-  <span class="headerTitle"> Widget preferences </span>
+  <span class="headerTitle">
+    Widget preferences
+  </span>
+
 </div>
 <mat-dialog-content>
-  <div class="preferences-container">
-    <form [formGroup]="options">
-      <mat-divider></mat-divider>
+<div class="preferences-container">
 
-      <mat-form-field required>
-        <mat-label>Title</mat-label>
-        <input matInput placeholder="Title" [formControl]="title" />
-      </mat-form-field>
-      <mat-form-field>
-        <mat-label>Widget type</mat-label>
-        <mat-select (selectionChange)="selectedWidgetType($event)" [formControl]="widgetType">
-          <mat-option value="logbook">Logbook</mat-option>
-          <!-- <mat-option value="chat">Chat</mat-option> -->
-          <mat-option value="graph">Graph</mat-option>
-          <mat-option value="tasks">Tasks</mat-option>
-          <mat-option value="snippetViewer">Snippet viewer</mat-option>
-          <mat-option *ngIf="scicatWidgetEnabled" value="scicatViewer">Scicat viewer</mat-option>
-        </mat-select>
-      </mat-form-field>
-      <mat-divider></mat-divider>
-      <div [ngSwitch]="widgetType.value">
-        <div *ngSwitchCase="'logbook'">
-          <div>
-            <mat-slide-toggle [formControl]="readOnlyLogbook">Read-only</mat-slide-toggle>
-          </div>
-          <ng-container *ngIf="!readOnlyLogbook.value">
-            <header class="subHeader">
-              <span matTooltip="New entries will be appended to this logbook.">Target logbook</span>
-            </header>
-            <div>
-              <mat-form-field style="width: 45%">
-                <mat-label>Logbook</mat-label>
-                <textarea
-                  matInput
-                  placeholder="Logbook"
-                  [matAutocomplete]="autoLogbook"
-                  [formControl]="filterBasics.get('logbook')"
-                  cdkTextareaAutosize
-                  #autosize="cdkTextareaAutosize"
-                  cdkAutosizeMinRows="1"
-                  cdkAutosizeMaxRows="5"
-                  required
-                ></textarea>
-                <mat-autocomplete
-                  #autoLogbook="matAutocomplete"
-                  [displayWith]="displayFnLogbookSelection"
-                >
-                  <mat-option *ngFor="let logbook of filteredLogbooks | async" [value]="logbook">
-                    {{ logbook.name }}
-                  </mat-option>
-                </mat-autocomplete>
-              </mat-form-field>
-              <mat-form-field>
-                <mat-label>ownerGroup</mat-label>
-                <input
-                  matInput
-                  placeholder="ownerGroup"
-                  [matAutocomplete]="autoOwnerGroup"
-                  [formControl]="filterBasics.get('ownerGroup')"
-                />
-                <mat-autocomplete #autoOwnerGroup="matAutocomplete">
-                  <mat-option *ngFor="let group of filteredOwnerGroups | async" [value]="group">
-                    {{ group }}
-                  </mat-option>
-                </mat-autocomplete>
-              </mat-form-field>
-            </div>
-            <div style="width: 100%">
-              <mat-form-field appearance="fill" style="width: 100%">
-                <mat-label>Logbook description</mat-label>
-                <textarea
-                  matInput
-                  [formControl]="filterBasics.get('description')"
-                  cdkTextareaAutosize
-                  #autosize="cdkTextareaAutosize"
-                  cdkAutosizeMinRows="1"
-                  cdkAutosizeMaxRows="5"
-                ></textarea>
-              </mat-form-field>
-            </div>
-          </ng-container>
+  <form [formGroup]="options">
+    <mat-divider></mat-divider>
 
-          <mat-divider></mat-divider>
-          <header class="subHeader">Filter settings</header>
-          <header class="subSubHeader">Additional logbooks</header>
-          <mat-form-field [floatLabel]="'auto'" class="chipList">
-            <mat-chip-grid #chipListLogbook aria-label="Logbook selection">
-              <mat-chip-row
-                *ngFor="let logbookItem of additionalLogbooks"
-                [removable]="removable"
-                (removed)="removeLogbook(logbookItem)"
-                [value]="logbookItem"
-                [matTooltip]="
-                  'Group: ' + logbookItem.ownerGroup + '; Description: ' + logbookItem.description
-                "
-              >
-                {{ logbookItem.name }}
-                <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
-              </mat-chip-row>
-              <input
-                #logbookInput
-                placeholder="Add logbooks"
-                [matChipInputFor]="chipListLogbook"
-                [matAutocomplete]="autoLogbookChip"
-                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-                [matChipInputAddOnBlur]="addOnBlur"
-                [formControl]="additionalLogbooksCtrl"
-              />
-            </mat-chip-grid>
-            <mat-autocomplete
-              #autoLogbookChip="matAutocomplete"
-              [displayWith]="displayFnLogbookSelection"
-              (optionSelected)="addLogbook($event)"
-            >
-              <mat-option
-                *ngFor="let logbook of filteredAdditionalLogbooks | async"
-                [value]="logbook"
-                [matTooltip]="
-                  'Group: ' + logbook.ownerGroup + '; Description: ' + logbook.description
-                "
-              >
-                {{ logbook.name }} ({{ logbook.ownerGroup }})
-              </mat-option>
-            </mat-autocomplete>
-          </mat-form-field>
+    <mat-form-field required>
+      <mat-label>Title</mat-label>
+      <input matInput placeholder="Title" [formControl]="title">
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Widget type</mat-label>
+      <mat-select (selectionChange)="selectedWidgetType($event)" [formControl]="widgetType">
+        <mat-option value="logbook">Logbook</mat-option>
+        <!-- <mat-option value="chat">Chat</mat-option> -->
+        <mat-option value="graph">Graph</mat-option>
+        <mat-option value="tasks">Tasks</mat-option>
+        <mat-option value="snippetViewer">Snippet viewer</mat-option>
+        <mat-option *ngIf="scicatWidgetEnabled" value="scicatViewer">Scicat viewer</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-divider></mat-divider>
+    <div [ngSwitch]="widgetType.value">
 
-          <header class="subSubHeader">Data must include the following tags</header>
-          <div class="chips">
-            <mat-chip-grid #chipList1 aria-label="Tag selection">
-              <mat-chip-row
-                *ngFor="let tagItem of tag"
-                [removable]="removable"
-                (removed)="removeTag(tagItem)"
-              >
-                {{ tagItem.name }}
-                <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
-              </mat-chip-row>
-              <input
-                placeholder="Add tags"
-                [matChipInputFor]="chipList1"
-                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-                [matChipInputAddOnBlur]="addOnBlur"
-                (matChipInputTokenEnd)="addTag($event)"
-              />
-            </mat-chip-grid>
-          </div>
-          <header class="subSubHeader">Data must NOT include the following tags</header>
-          <div class="chips">
-            <mat-chip-grid #chipList2 aria-label="Tag selection">
-              <mat-chip-row
-                *ngFor="let tagItem of excludeTag"
-                [removable]="removable"
-                (removed)="removeExcludeTag(tagItem)"
-              >
-                {{ tagItem.name }}
-                <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
-              </mat-chip-row>
-              <input
-                placeholder="Add tags"
-                [matChipInputFor]="chipList2"
-                [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-                [matChipInputAddOnBlur]="addOnBlur"
-                (matChipInputTokenEnd)="addExcludeTag($event)"
-              />
-            </mat-chip-grid>
-          </div>
-          <mat-divider></mat-divider>
-          <header class="subHeader">View settings</header>
-          <div>
-            <mat-slide-toggle [formControl]="hideMetadata">Hide metadata</mat-slide-toggle>
-          </div>
-          <div>
-            <mat-slide-toggle [formControl]="showSnippetHeader"
-              >Show timestamp and author information</mat-slide-toggle
-            >
-          </div>
-          <div>
-            <mat-slide-toggle [formControl]="descendingOrder"
-              >Show data in descending order</mat-slide-toggle
-            >
-          </div>
+      <div *ngSwitchCase="'logbook'">
+        <div>
+          <mat-slide-toggle [formControl]="readOnlyLogbook">Read-only</mat-slide-toggle>
         </div>
-        <div *ngSwitchCase="'chat'">Chat</div>
-        <div *ngSwitchCase="'graph'">
-          <mat-form-field class="example-full-width">
-            <input
-              type="text"
-              placeholder="Select plot"
-              aria-label="Name"
-              matInput
-              [formControl]="plotControl"
-              [matAutocomplete]="auto"
-            />
-            <mat-autocomplete
-              autoActiveFirstOption
-              #auto="matAutocomplete"
-              [displayWith]="displayFnSnippetSelectionPlot"
-            >
-              <mat-option *ngFor="let plot of filteredOptionsPlot | async" [value]="plot">
-                {{ plot['name'] }}
-              </mat-option>
-            </mat-autocomplete>
-          </mat-form-field>
-        </div>
-        <div *ngSwitchCase="'snippetViewer'">
-          <mat-form-field class="example-full-width">
-            <input
-              type="text"
-              placeholder="Select snippet"
-              aria-label="Name"
-              matInput
-              [formControl]="snippetViewerControl"
-              [matAutocomplete]="auto"
-            />
-            <mat-autocomplete
-              autoActiveFirstOption
-              #auto="matAutocomplete"
-              [displayWith]="displayFnSnippetSelection"
-            >
-              <mat-option
-                *ngFor="let dashboardName of filteredOptions | async"
-                [value]="dashboardName"
-              >
-                {{ dashboardName.dashboardName }}
-              </mat-option>
-            </mat-autocomplete>
-          </mat-form-field>
+        <ng-container *ngIf='!readOnlyLogbook.value'>
+          <header class="subHeader">
+            <span matTooltip="New entries will be appended to this logbook.">Target logbook</span>
+          </header>
+          <div>
+            <mat-form-field style="width: 45%;">
+              <mat-label>Logbook</mat-label>
+              <textarea matInput placeholder="Logbook" [matAutocomplete]="autoLogbook"
+                [formControl]="filterBasics.get('logbook')" cdkTextareaAutosize #autosize="cdkTextareaAutosize"
+                cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5" required></textarea>
+              <mat-autocomplete #autoLogbook="matAutocomplete" [displayWith]="displayFnLogbookSelection">
+                <mat-option *ngFor="let logbook of filteredLogbooks | async" [value]="logbook">
+                  {{logbook.name}}
+                </mat-option>
+              </mat-autocomplete>
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>ownerGroup</mat-label>
+              <input matInput placeholder="ownerGroup" [matAutocomplete]="autoOwnerGroup"
+                [formControl]="filterBasics.get('ownerGroup')">
+              <mat-autocomplete #autoOwnerGroup="matAutocomplete">
+                <mat-option *ngFor="let group of filteredOwnerGroups | async" [value]="group">
+                  {{group}}
+                </mat-option>
+              </mat-autocomplete>
+            </mat-form-field>
+          </div>
+          <div style="width: 100%;">
+            <mat-form-field appearance="fill" style="width: 100%;">
+              <mat-label>Logbook description</mat-label>
+              <textarea matInput [formControl]="filterBasics.get('description')" cdkTextareaAutosize
+                #autosize="cdkTextareaAutosize" cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"></textarea>
+            </mat-form-field>
+          </div>
+        </ng-container>
 
-          <!-- <div *ngFor="let snippet of (snippetViewerOptions | async)?.dashboardName">
+        <mat-divider></mat-divider>
+        <header class="subHeader">
+          Filter settings
+        </header>
+        <header class="subSubHeader">
+          Additional logbooks
+        </header>
+        <mat-form-field [floatLabel]="'auto'" class="chipList">
+          <mat-chip-grid #chipListLogbook aria-label="Logbook selection">
+            <mat-chip-row *ngFor="let logbookItem of additionalLogbooks" [removable]="removable"
+              (removed)="removeLogbook(logbookItem)" [value]="logbookItem"
+              [matTooltip]="'Group: ' + logbookItem.ownerGroup + '; Description: ' + logbookItem.description">
+              {{ logbookItem.name }}
+              <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
+            </mat-chip-row>
+            <input #logbookInput placeholder="Add logbooks" [matChipInputFor]="chipListLogbook"
+              [matAutocomplete]="autoLogbookChip" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+              [matChipInputAddOnBlur]="addOnBlur" [formControl]="additionalLogbooksCtrl">
+          </mat-chip-grid>
+          <mat-autocomplete #autoLogbookChip="matAutocomplete" [displayWith]="displayFnLogbookSelection"
+            (optionSelected)="addLogbook($event)">
+            <mat-option *ngFor="let logbook of filteredAdditionalLogbooks | async" [value]="logbook"
+              [matTooltip]="'Group: ' + logbook.ownerGroup + '; Description: ' + logbook.description">
+              {{logbook.name}} ({{logbook.ownerGroup}})
+            </mat-option>
+          </mat-autocomplete>
+        </mat-form-field>
+
+       <header class="subSubHeader">
+        Importance
+      </header>
+
+
+<div class="importance-checkboxes">
+  <mat-checkbox
+    *ngFor="let level of importanceLevels"
+    [checked]="importance.value?.includes(level)"
+    (change)="onImportanceChange(level, $event.checked)">
+    {{ level }}
+  </mat-checkbox>
+</div>
+
+
+
+      <header class="subSubHeader">
+        Data must include the following tags
+      </header>
+
+
+        <div class="chips">
+          <mat-chip-grid #chipList1 aria-label="Tag selection">
+            <mat-chip-row *ngFor="let tagItem of tag" [removable]="removable"
+              (removed)="removeTag(tagItem)">
+              {{ tagItem.name }}
+              <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
+            </mat-chip-row>
+            <input placeholder="Add tags" [matChipInputFor]="chipList1"
+              [matChipInputSeparatorKeyCodes]="separatorKeysCodes" [matChipInputAddOnBlur]="addOnBlur"
+              (matChipInputTokenEnd)="addTag($event)">
+          </mat-chip-grid>
+        </div>
+        <header class="subSubHeader">
+          Data must NOT include the following tags
+        </header>
+        <div class="chips">
+          <mat-chip-grid #chipList2 aria-label="Tag selection">
+            <mat-chip-row *ngFor="let tagItem of excludeTag" [removable]="removable"
+              (removed)="removeExcludeTag(tagItem)">
+              {{ tagItem.name }}
+              <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
+            </mat-chip-row>
+            <input placeholder="Add tags" [matChipInputFor]="chipList2"
+              [matChipInputSeparatorKeyCodes]="separatorKeysCodes" [matChipInputAddOnBlur]="addOnBlur"
+              (matChipInputTokenEnd)="addExcludeTag($event)">
+          </mat-chip-grid>
+        </div>
+        <mat-divider></mat-divider>
+        <header class="subHeader">
+          View settings
+        </header>
+        <div>
+          <mat-slide-toggle [formControl]="hideMetadata">Hide metadata</mat-slide-toggle>
+        </div>
+        <div>
+          <mat-slide-toggle [formControl]="showSnippetHeader">Show timestamp and author information</mat-slide-toggle>
+        </div>
+        <div>
+          <mat-slide-toggle [formControl]="descendingOrder">Show data in descending order</mat-slide-toggle>
+        </div>
+
+      </div>
+      <div *ngSwitchCase="'chat'">
+        Chat
+      </div>
+      <div *ngSwitchCase="'graph'">
+        <mat-form-field class="example-full-width">
+          <input type="text" placeholder="Select plot" aria-label="Name" matInput [formControl]="plotControl"
+            [matAutocomplete]="auto">
+          <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete" [displayWith]="displayFnSnippetSelectionPlot">
+            <mat-option *ngFor="let plot of filteredOptionsPlot | async" [value]="plot">
+              {{plot["name"]}}
+            </mat-option>
+          </mat-autocomplete>
+        </mat-form-field>
+      </div>
+      <div *ngSwitchCase="'snippetViewer'">
+        <mat-form-field class="example-full-width">
+          <input type="text" placeholder="Select snippet" aria-label="Name" matInput
+            [formControl]="snippetViewerControl" [matAutocomplete]="auto">
+          <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete" [displayWith]="displayFnSnippetSelection">
+            <mat-option *ngFor="let dashboardName of filteredOptions | async" [value]="dashboardName">
+              {{dashboardName.dashboardName}}
+            </mat-option>
+          </mat-autocomplete>
+        </mat-form-field>
+
+        <!-- <div *ngFor="let snippet of (snippetViewerOptions | async)?.dashboardName">
             {{snippet.id}}
               
           </div> -->
-        </div>
       </div>
-    </form>
-  </div>
+
+    </div>
+  </form>
+</div>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
   <button mat-button (click)="close()">Cancel</button>
-  <button
-    mat-button
-    (click)="applyChanges($event)"
-    [disabled]="filterBasics.get('logbook').invalid"
-  >
-    Apply
-  </button>
+  <button mat-button (click)="applyChanges($event)" [disabled]="filterBasics.get('logbook').invalid">Apply</button>
 </mat-dialog-actions>

--- a/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.ts
+++ b/scilog/src/app/logbook/widgets/widget-preferences/widget-preferences.component.ts
@@ -1,38 +1,9 @@
-import {
-  Component,
-  OnInit,
-  Inject,
-  ViewChild,
-  NgZone,
-  ElementRef,
-  ChangeDetectorRef,
-  AfterViewInit,
-  OnDestroy,
-} from '@angular/core';
-import {
-  UntypedFormArray,
-  UntypedFormBuilder,
-  UntypedFormControl,
-  UntypedFormGroup,
-  FormsModule,
-  ReactiveFormsModule,
-} from '@angular/forms';
-import {
-  MatChipInputEvent,
-  MatChipGrid,
-  MatChipRow,
-  MatChipRemove,
-  MatChipInput,
-} from '@angular/material/chips';
+import { Component, OnInit, Inject, ViewChild, NgZone, ElementRef, ChangeDetectorRef, AfterViewInit, OnDestroy } from '@angular/core';
+import { UntypedFormArray, UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatChipInputEvent, MatChipGrid, MatChipRow, MatChipRemove, MatChipInput } from '@angular/material/chips';
 import { COMMA, ENTER, SPACE } from '@angular/cdk/keycodes';
-import {
-  MatDialogRef,
-  MAT_DIALOG_DATA,
-  MatDialogTitle,
-  MatDialogContent,
-  MatDialogActions,
-} from '@angular/material/dialog';
-import { Tags } from '@model/metadata';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogTitle, MatDialogContent, MatDialogActions } from '@angular/material/dialog';
+import { Tags } from '@model/metadata'
 import { Observable, Subscription } from 'rxjs';
 import { Basesnippets } from '@model/basesnippets';
 import { map, startWith, take } from 'rxjs/operators';
@@ -55,43 +26,18 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { MatAutocompleteTrigger, MatAutocomplete } from '@angular/material/autocomplete';
 import { MatIcon } from '@angular/material/icon';
 import { MatButton } from '@angular/material/button';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 
 @Component({
-  selector: 'app-widget-preferences',
-  templateUrl: './widget-preferences.component.html',
-  styleUrls: ['./widget-preferences.component.scss'],
-  imports: [
-    MatDialogTitle,
-    CdkScrollable,
-    MatDialogContent,
-    FormsModule,
-    ReactiveFormsModule,
-    MatDivider,
-    MatFormField,
-    MatLabel,
-    MatInput,
-    MatSelect,
-    MatOption,
-    NgIf,
-    NgSwitch,
-    NgSwitchCase,
-    MatSlideToggle,
-    MatTooltip,
-    CdkTextareaAutosize,
-    MatAutocompleteTrigger,
-    MatAutocomplete,
-    NgFor,
-    MatChipGrid,
-    MatChipRow,
-    MatIcon,
-    MatChipRemove,
-    MatChipInput,
-    MatDialogActions,
-    MatButton,
-    AsyncPipe,
-  ],
+    selector: 'app-widget-preferences',
+    templateUrl: './widget-preferences.component.html',
+    styleUrls: ['./widget-preferences.component.scss'],
+    imports: [MatDialogTitle, CdkScrollable, MatDialogContent, FormsModule, ReactiveFormsModule, MatDivider, MatFormField, MatLabel, MatInput, MatSelect, MatOption, NgIf, NgSwitch, NgSwitchCase, MatSlideToggle, MatTooltip, CdkTextareaAutosize, MatAutocompleteTrigger, MatAutocomplete, NgFor, MatChipGrid, MatChipRow, MatIcon, MatChipRemove, MatChipInput, MatDialogActions, MatButton, AsyncPipe,MatRadioModule,MatCheckboxModule]
 })
 export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDestroy {
+
+
   data: WidgetItemConfig;
   filters = new UntypedFormArray([]);
   options: UntypedFormGroup;
@@ -110,6 +56,9 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
   snippetViewerControl = new UntypedFormControl();
   plotControl = new UntypedFormControl();
   additionalLogbooksCtrl = new UntypedFormControl();
+  importanceLevels = [1, 2, 3, 4, 5];
+  importance = new UntypedFormControl([]);
+
 
   visible = true;
   removable = true;
@@ -143,8 +92,7 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
     @Inject(MAT_DIALOG_DATA) data,
     private _ngZone: NgZone,
     protected changeDetectorRef: ChangeDetectorRef,
-    private appConfigService: AppConfigService,
-  ) {
+    private appConfigService: AppConfigService) {
     this.data = data.config;
     this.options = fb.group({
       hideRequired: this.hideRequiredControl,
@@ -154,10 +102,10 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
     this.filterBasics = fb.group({
       ownerGroup: new UntypedFormControl(''),
       logbook: new UntypedFormControl(''),
-      description: new UntypedFormControl({ value: '', disabled: true }),
+      description: new UntypedFormControl({ value: "", disabled: true }),
+      importance: this.importance 
     });
-    this.scicatWidgetEnabled =
-      this.appConfigService.getScicatSettings()?.scicatWidgetEnabled || false;
+    this.scicatWidgetEnabled = this.appConfigService.getScicatSettings()?.scicatWidgetEnabled || false;
   }
 
   ngOnInit(): void {
@@ -168,27 +116,32 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
       this.data.filter.tags.forEach((tag: string) => {
         console.log(tag);
         this.tag.push({ name: tag });
-      });
+      })
     }
+ if (Array.isArray(this.data.filter.importance)) {
+  this.importance.setValue(this.data.filter.importance);
+}
+
+
     if (this.data.filter.excludeTags?.length > 0) {
       this.data.filter.excludeTags.forEach((tag: string) => {
         console.log(tag);
         this.excludeTag.push({ name: tag });
-      });
+      })
     }
-    if (typeof this.data.view.hideMetadata != 'undefined') {
+    if (typeof this.data.view.hideMetadata != "undefined") {
       this.hideMetadata.setValue(this.data.view.hideMetadata);
     }
-    if (typeof this.data.view.showSnippetHeader != 'undefined') {
+    if (typeof this.data.view.showSnippetHeader != "undefined") {
       this.showSnippetHeader.setValue(this.data.view.showSnippetHeader);
     }
-    if (typeof this.data.general.readonly != 'undefined') {
+    if (typeof this.data.general.readonly != "undefined") {
       this.readOnlyLogbook.setValue(this.data.general.readonly);
     }
-    if (typeof this.data.view.order != 'undefined') {
-      let orderTag = this.data.view.order[0].split(' ')[1];
-      console.log(this.data.view.order);
-      console.log(orderTag);
+    if (typeof this.data.view.order != "undefined") {
+      let orderTag = this.data.view.order[0].split(" ")[1];
+      console.log(this.data.view.order)
+      console.log(orderTag)
       this.descendingOrder.setValue(this.orderTagToBoolean(orderTag));
     }
     this.getSnippetViewerOptions();
@@ -202,32 +155,25 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
     this.setUpAdditionalLogbooks();
 
     // target logbook description
-    this.subscriptions.push(
-      this.filterBasics.get('logbook').valueChanges.subscribe((logbook) => {
-        if (logbook && logbook.description) {
-          this.filterBasics.get('description').setValue(logbook.description);
-        } else {
-          this.filterBasics.get('description').setValue('');
-        }
-      }),
-    );
+    this.subscriptions.push(this.filterBasics.get('logbook').valueChanges.subscribe(logbook => {
+      if (logbook && logbook.description) {
+        this.filterBasics.get('description').setValue(logbook.description);
+      } else {
+        this.filterBasics.get('description').setValue("");
+      }
+    }));
 
     // ownerGroups
     this.ownerGroupsAvail = this.userPreferences.userInfo?.roles;
     this.filteredOwnerGroups = this.filterBasics.get('ownerGroup').valueChanges.pipe(
-      startWith(null),
-      map((ownerGroup: string | null) =>
-        ownerGroup ? this._filterOwnerGroups(ownerGroup) : this.ownerGroupsAvail.slice(),
-      ),
-    );
-    this.filterBasics
-      .get('ownerGroup')
-      .setValidators([ownerGroupMemberValidator(this.ownerGroupsAvail)]);
+      startWith(null), 
+      map((ownerGroup: string | null) => ownerGroup ? this._filterOwnerGroups(ownerGroup) : this.ownerGroupsAvail.slice()));
+    this.filterBasics.get('ownerGroup').setValidators([ownerGroupMemberValidator(this.ownerGroupsAvail)]);
     this.changeDetectorRef.detectChanges();
     // let ownerGroupIndex = Object.keys(this.data.filters).find(k => this.data.filters[k].name == 'ownerGroup');
     // if (typeof ownerGroupIndex != 'undefined') {
     //   this.filterBasics.get('ownerGroup').setValue(this.data.filters[ownerGroupIndex].value);
-    // }
+    // } 
   }
 
   private async setUpAdditionalLogbooks() {
@@ -250,32 +196,46 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
     // basic filter forms
     this.setupLogbookSelection();
   }
+  
+onImportanceChange(level: number, checked: boolean) {
+  const current: number[] = this.importance.value || [];
+
+  if (checked) {
+    if (!current.includes(level)) {
+      this.importance.setValue([...current, level]);
+    }
+  } else {
+    this.importance.setValue(current.filter(v => v !== level));
+  }
+}
+
+
 
   async getSnippetViewerOptions() {
     let data = await this.dataService.getSnippetsForLogbook(this.logbookInfo.logbookInfo.id);
     // TODO this should be done in the backend, not here!
     this.snippetViewerOptions = [];
-    data.forEach((snippet) => {
+    data.forEach(snippet => {
       if (snippet?.dashboardName) {
-        this.snippetViewerOptions.push(snippet);
+        this.snippetViewerOptions.push(snippet)
       }
-    });
+    })
     this.filteredOptions = this.snippetViewerControl.valueChanges.pipe(
       startWith(''),
-      map((value) => (typeof value === 'string' ? value : value.name)),
-      map((name) => (name ? this._filter(name) : this.snippetViewerOptions.slice())),
+      map(value => typeof value === 'string' ? value : value.name),
+      map(name => name ? this._filter(name) : this.snippetViewerOptions.slice())
     );
-    console.log(this.snippetViewerOptions);
+    console.log(this.snippetViewerOptions)
   }
 
   async getFilterOptionsPlot() {
     let data = await this.dataService.getPlotSnippets(this.logbookInfo.logbookInfo.id);
-    console.log(data);
+    console.log(data)
     this.plotOptions = data;
     this.filteredOptionsPlot = this.plotControl.valueChanges.pipe(
       startWith(''),
-      map((value) => (typeof value === 'string' ? value : value.name)),
-      map((name) => (name ? this._filter(name) : this.plotOptions.slice())),
+      map(value => typeof value === 'string' ? value : value.name),
+      map(name => name ? this._filter(name) : this.plotOptions.slice())
     );
   }
 
@@ -284,16 +244,11 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
     // taget logbooks
     this.filteredLogbooks = this.filterBasics.get('logbook').valueChanges.pipe(
       startWith(''),
-      map((value) => (typeof value === 'string' ? value : value.name)),
-      map((name) => (name ? this._filterLogbooks(name) : this.logbookInfo.availLogbooks.slice())),
+      map(value => typeof value === 'string' ? value : value.name),
+      map(name => name ? this._filterLogbooks(name) : this.logbookInfo.availLogbooks.slice())
     );
     // additional logbooks
-    this.filteredAdditionalLogbooks = this.additionalLogbooksCtrl.valueChanges.pipe(
-      startWith(null),
-      map((logbook: string) =>
-        logbook ? this._filterAdditionalLogbooks(logbook) : this._getAvailAdditionalLogbooks(),
-      ),
-    );
+    this.filteredAdditionalLogbooks = this.additionalLogbooksCtrl.valueChanges.pipe(startWith(null), map((logbook: string) => logbook ? this._filterAdditionalLogbooks(logbook) : this._getAvailAdditionalLogbooks()));
   }
 
   selectedWidgetType($event) {
@@ -304,7 +259,7 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
     const input = event.input;
     const value = event.value;
 
-    if ((value ?? '').trim()) {
+    if ((value ?? "").trim()) {
       this.tag.push({ name: value.trim() });
     }
 
@@ -330,18 +285,18 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
     let availLogbooks = this.logbookInfo.availLogbooks;
     if (this.filterBasics.get('logbook').value.id) {
       availLogbooks = availLogbooks.filter((log) => {
-        return log.id != this.filterBasics.get('logbook').value.id;
-      });
+        return log.id != this.filterBasics.get('logbook').value.id
+      })
     }
     if (this.additionalLogbooks.length > 0) {
       availLogbooks = availLogbooks.filter((log) => {
         return this.additionalLogbooks.indexOf(log) < 0;
-      });
+      })
     }
-    if (this.additionalLogbooksCtrl.value != null && this.additionalLogbooksCtrl.value?.id) {
-      availLogbooks = availLogbooks.filter((log) => {
+    if ((this.additionalLogbooksCtrl.value != null) && (this.additionalLogbooksCtrl.value?.id)) {
+      availLogbooks = availLogbooks.filter(log => {
         return log.id != this.additionalLogbooksCtrl.value.id;
-      });
+      })
     }
     return availLogbooks;
   }
@@ -355,11 +310,11 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
     this.additionalLogbooks.push($event.option.value);
     // }
 
-    this.logbookInput.nativeElement.value = '';
+    this.logbookInput.nativeElement.value = "";
   }
 
   addNewFormGroupAfterEmpty() {
-    if (this.filters.at(this.filters.length - 1).value.name != '' && this.filters.length < 20) {
+    if (this.filters.at(this.filters.length - 1).value.name != "" && this.filters.length < 20) {
       this.addFormGroup();
     }
   }
@@ -368,7 +323,7 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
     const group = new UntypedFormGroup({
       name: new UntypedFormControl(''),
       operator: new UntypedFormControl(''),
-      value: new UntypedFormControl(''),
+      value: new UntypedFormControl('')
     });
     this.filters.push(group);
   }
@@ -402,45 +357,37 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
 
   private _filter(value: string): Basesnippets[] {
     const filterValue = value.toLowerCase();
-    return this.snippetViewerOptions.filter(
-      (option) =>
-        option?.dashboardName && option.dashboardName.toLowerCase().indexOf(filterValue) === 0,
-    );
+    return this.snippetViewerOptions.filter(option => option?.dashboardName && option.dashboardName.toLowerCase().indexOf(filterValue) === 0);
   }
 
   private _filterOwnerGroups(value: string): string[] {
-    console.log(value);
+    console.log(value)
     const filterValue = value.toLowerCase();
 
-    return this.ownerGroupsAvail.filter(
-      (ownerGroup) => ownerGroup.toLowerCase().indexOf(filterValue) === 0,
-    );
+    return this.ownerGroupsAvail.filter(ownerGroup => ownerGroup.toLowerCase().indexOf(filterValue) === 0);
   }
 
   private _filterAdditionalLogbooks(value: string): Logbooks[] {
     console.log(value);
     let additionalLogbooks = this._getAvailAdditionalLogbooks();
 
-    return additionalLogbooks.filter((log) => {
+    return additionalLogbooks.filter(log => {
       if (typeof value == 'string') {
         if (log?.name) {
-          return (
-            log?.name.toLowerCase().includes(value.toLowerCase()) ||
-            log?.description.toLowerCase().includes(value.toLowerCase()) ||
-            log?.ownerGroup.toLowerCase().includes(value.toLowerCase())
-          );
+          return (log?.name.toLowerCase().includes(value.toLowerCase()) || (log?.description.toLowerCase().includes(value.toLowerCase())) || (log?.ownerGroup.toLowerCase().includes(value.toLowerCase())));
         }
         return false;
       } else {
         return true;
       }
-    });
+    }
+    );
   }
 
   private _filterLogbooks(value: string): Logbooks[] {
-    console.log(value);
+    console.log(value)
     const filterValue = value.toLowerCase();
-    return this.logbookInfo.availLogbooks.filter((log) => {
+    return this.logbookInfo.availLogbooks.filter(log => {
       if (log?.name) {
         return log?.name.toLowerCase().includes(value.toLowerCase());
       }
@@ -453,7 +400,7 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
   }
 
   displayFnSnippetSelectionPlot(snippet: Basesnippets): string {
-    return snippet && snippet['name'] ? snippet['name'] : '';
+    return snippet && snippet["name"] ? snippet["name"] : '';
   }
 
   displayFnLogbookSelection(logbook: Logbooks): string {
@@ -462,17 +409,19 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
 
   triggerResize() {
     // Wait for changes to be applied, then trigger textarea resize.
-    this._ngZone.onStable.pipe(take(1)).subscribe(() => this.autosize.resizeToFitContent(true));
+    this._ngZone.onStable.pipe(take(1))
+      .subscribe(() => this.autosize.resizeToFitContent(true));
   }
 
   applyChanges($event) {
     this.data.general.title = this.title.value;
     this.data.general.type = this.widgetType.value;
 
+
     switch (this.data.general.type) {
       case 'logbook':
         this.data.filter.targetId = this.filterBasics.get('logbook').value.id;
-        this.data.filter.additionalLogbooks = this.additionalLogbooks.map((log) => log.id);
+        this.data.filter.additionalLogbooks = this.additionalLogbooks.map(log => log.id);
         break;
       case 'snippetViewer':
         this.data.filter.targetId = this.snippetViewerControl.value?.id;
@@ -484,29 +433,39 @@ export class WidgetPreferencesComponent implements OnInit, AfterViewInit, OnDest
         break;
     }
     // this.data.filter.targetId = this.filterBasics.get('logbook').value.id;
-    this.data.filter.tags = this.tag.map((tag) => tag.name);
-    this.data.filter.excludeTags = this.excludeTag.map((tag) => tag.name);
+    this.data.filter.tags = this.tag.map(tag => tag.name);
+    this.data.filter.excludeTags = this.excludeTag.map(tag => tag.name);
     this.data.view.hideMetadata = this.hideMetadata.value;
     this.data.view.showSnippetHeader = this.showSnippetHeader.value;
     this.data.general.readonly = this.readOnlyLogbook.value;
     this.data.view.order = ['defaultOrder ' + this.booleanToOrderTag(this.descendingOrder.value)];
     console.log(this.data);
+    if (this.importance.value && this.importance.value.length > 0) {
+  this.data.filter.importance = this.importance.value;
+  console.log("APPLY IMPORTANCE:", this.importance.value);
+
+} else {
+  delete this.data.filter.importance;
+}
+
+
+
     this.dialogRef.close(this.data);
   }
 
   booleanToOrderTag(descending: boolean): string {
-    return descending ? 'DESC' : 'ASC';
+    return descending ? "DESC" : "ASC"
   }
 
   orderTagToBoolean(orderTag: string) {
-    return orderTag == 'DESC' ? true : false;
+    return orderTag == "DESC" ? true : false;
   }
 
   ngOnDestroy(): void {
     //Called once, before the instance is destroyed.
     //Add 'implements OnDestroy' to the class.
-    this.subscriptions.forEach((sub) => {
+    this.subscriptions.forEach(sub => {
       sub.unsubscribe();
-    });
+    })
   }
 }


### PR DESCRIPTION
### Summary

This PR introduces an **importance level feature (1–5)** for logbook paragraphs. The feature allows users to assign a priority level when submitting a paragraph and enables filtering logbook entries based on selected importance levels.

### Motivation

Adding importance levels improves content prioritization and helps users quickly identify and filter relevant logbook entries.

### Implementation

The following changes were implemented:

* Added support for assigning an **importance level (1–5)** when submitting a paragraph.
* Implemented a **default importance value of 3** if no value is selected.
* Stored the selected importance value together with the paragraph data.
* Updated the UI to allow selecting importance levels during paragraph submission.
* Added **filtering functionality in the widget modal popup**.
* Users can **filter logbook entries by selecting one or multiple importance levels** using checkboxes.

### Importance Levels

* **1** – Lowest importance
* **5** – Highest importance
* **Default:** 3

### Result

Users can now assign importance to paragraphs and filter logbook entries based on one or multiple importance levels, improving navigation and prioritization within the logbook.
