### PR TITLE
Move dev-only deps and bump to latest

### DIFF
--- a/sci-log-db/package-lock.json
+++ b/sci-log-db/package-lock.json
@@ -18,7 +18,6 @@
         "@loopback/rest": "15.0.11",
         "@loopback/rest-explorer": "8.0.11",
         "@loopback/service-proxy": "8.0.10",
-        "@types/multer": "^1.4.4",
         "archiver": "^7.0.1",
         "connect-mongo": "^4.6.0",
         "express-session": "^1.17.3",
@@ -36,8 +35,7 @@
         "ro-crate": "^3.6.1",
         "ro-crate-html": "^0.1.6",
         "tar": "^6.2.0",
-        "tslib": "2.0.0",
-        "yauzl": "^3.2.0"
+        "tslib": "2.0.0"
       },
       "devDependencies": {
         "@loopback/build": "12.0.10",
@@ -48,6 +46,7 @@
         "@types/formidable": "^2.0.5",
         "@types/jsdom": "^21.1.0",
         "@types/ldapjs": "^1.0.9",
+        "@types/multer": "2.1.0",
         "@types/node": "16.18.126",
         "@types/passport": "^1.0.7",
         "@types/prismjs": "^1.26.0",
@@ -55,7 +54,8 @@
         "eslint": "8.57.1",
         "source-map-support": "0.5.21",
         "tsc-watch": "^5.0.3",
-        "typescript": "5.2.2"
+        "typescript": "5.2.2",
+        "yauzl": "3.2.1"
       },
       "engines": {
         "node": ">=10.16"
@@ -4272,9 +4272,11 @@
       "license": "MIT"
     },
     "node_modules/@types/multer": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.4.tgz",
-      "integrity": "sha512-wdfkiKBBEMTODNbuF3J+qDDSqJxt50yB9pgDiTcFew7f97Gcc7/sM4HR66ofGgpJPOALWOqKAch4gPyqEXSkeQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/express": "*"
       }
@@ -14350,9 +14352,10 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
-      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
+      "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/sci-log-db/package.json
+++ b/sci-log-db/package.json
@@ -60,7 +60,6 @@
     "@loopback/rest": "15.0.11",
     "@loopback/rest-explorer": "8.0.11",
     "@loopback/service-proxy": "8.0.10",
-    "@types/multer": "^1.4.4",
     "archiver": "^7.0.1",
     "connect-mongo": "^4.6.0",
     "express-session": "^1.17.3",
@@ -78,8 +77,7 @@
     "ro-crate": "^3.6.1",
     "ro-crate-html": "^0.1.6",
     "tar": "^6.2.0",
-    "tslib": "2.0.0",
-    "yauzl": "^3.2.0"
+    "tslib": "2.0.0"
   },
   "devDependencies": {
     "@loopback/build": "12.0.10",
@@ -90,6 +88,7 @@
     "@types/formidable": "^2.0.5",
     "@types/jsdom": "^21.1.0",
     "@types/ldapjs": "^1.0.9",
+    "@types/multer": "2.1.0",
     "@types/node": "16.18.126",
     "@types/passport": "^1.0.7",
     "@types/prismjs": "^1.26.0",
@@ -97,6 +96,7 @@
     "eslint": "8.57.1",
     "source-map-support": "0.5.21",
     "tsc-watch": "^5.0.3",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "yauzl": "3.2.1"
   }
 }


### PR DESCRIPTION
These packages are only needed at build/dev time — @types/multer
provides TypeScript type definitions and yauzl is used for tests/tooling
— so they don't belong in production dependencies. Bumping to latest
versions (multer 1.4.4→2.1.0, yauzl 3.2.0→3.2.1) while at it.
