### PR TITLE
fix(deps): upgrade tar to v7.5.11

### DIFF
--- a/sci-log-db/package-lock.json
+++ b/sci-log-db/package-lock.json
@@ -34,7 +34,7 @@
         "puppeteer": "19.11.1",
         "ro-crate": "3.6.1",
         "ro-crate-html": "0.1.6",
-        "tar": "6.2.1",
+        "tar": "7.5.11",
         "tslib": "2.0.0"
       },
       "devDependencies": {
@@ -50,7 +50,6 @@
         "@types/node": "16.18.126",
         "@types/passport": "1.0.17",
         "@types/prismjs": "1.26.6",
-        "@types/tar": "6.1.13",
         "eslint": "8.57.1",
         "source-map-support": "0.5.21",
         "tsc-watch": "5.0.3",
@@ -1517,6 +1516,27 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -4157,17 +4177,6 @@
         "@types/superagent": "*"
       }
     },
-    "node_modules/@types/tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "minipass": "^4.0.0"
-      }
-    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -5611,12 +5620,12 @@
       }
     },
     "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/chromium-bidi": {
@@ -7687,36 +7696,6 @@
       "engines": {
         "node": ">=14.14"
       }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -9853,46 +9832,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 18"
       }
     },
     "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/mitt": {
       "version": "3.0.0",
@@ -13676,21 +13635,19 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/tar-fs": {
@@ -13765,19 +13722,22 @@
       }
     },
     "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/teex": {
       "version": "1.0.1",

--- a/sci-log-db/package.json
+++ b/sci-log-db/package.json
@@ -76,7 +76,7 @@
     "puppeteer": "19.11.1",
     "ro-crate": "3.6.1",
     "ro-crate-html": "0.1.6",
-    "tar": "6.2.1",
+    "tar": "7.5.11",
     "tslib": "2.0.0"
   },
   "devDependencies": {
@@ -92,7 +92,6 @@
     "@types/node": "16.18.126",
     "@types/passport": "1.0.17",
     "@types/prismjs": "1.26.6",
-    "@types/tar": "6.1.13",
     "eslint": "8.57.1",
     "source-map-support": "0.5.21",
     "tsc-watch": "5.0.3",

--- a/sci-log-db/src/__tests__/unit/service.export-snippet.unit.ts
+++ b/sci-log-db/src/__tests__/unit/service.export-snippet.unit.ts
@@ -9,7 +9,6 @@ import PDFMerger from 'pdf-merger-js';
 import puppeteer from 'puppeteer';
 import fspromise from 'fs/promises';
 import fs from 'fs';
-import tar from 'tar';
 
 describe('Export service unit', function (this: Suite) {
   let tests: string[] | string[][];
@@ -399,7 +398,9 @@ describe('Export service unit', function (this: Suite) {
     it(`zipAttachments ${i}`, async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       exportService.attachments = t.input as any;
-      const tarSpy = sandbox.stub(tar, 'create');
+      const tarSpy = sandbox.stub();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      exportService.createTar = tarSpy as any;
       sandbox.stub(fs, 'mkdirSync');
 
       const downloadAttachmentSpy = sandbox.stub(

--- a/sci-log-db/src/services/export-snippets.service.ts
+++ b/sci-log-db/src/services/export-snippets.service.ts
@@ -37,6 +37,7 @@ export class ExportService {
   attachments: string[][] = [];
   attachmentsFolder = 'attachments';
   authorizationHeader: {authorization?: string};
+  createTar = tarCreate;
 
   constructor(
     @inject(RestBindings.SERVER)
@@ -335,10 +336,10 @@ export class ExportService {
       this.attachments.map(downloadAttachmentDestinationBinding),
     );
     const exportZip = `${exportPath.exportDir}.gz`;
-    await tarCreate({gzip: true, file: exportZip, C: exportPath.exportDir}, [
-      this.attachmentsFolder,
-      basename(exportPath.exportFile),
-    ]);
+    await this.createTar(
+      {gzip: true, file: exportZip, C: exportPath.exportDir},
+      [this.attachmentsFolder, basename(exportPath.exportFile)],
+    );
     return exportZip;
   }
 


### PR DESCRIPTION
tar v7 is ESM-only, which means its named exports are frozen and
cannot be stubbed by sinon at the module level. To maintain
testability, the tarCreate import is now exposed as a class property
(createTar) on ExportService, allowing tests to replace it with a
stub via simple property assignment.

The default import in the test (import tar from 'tar') was also
removed since tar v7 has no default export.

Removed @types/tar from devDependencies since tar v7 ships its own
type definitions.

The stub assignment in the test uses an `as any` cast because tar
v7's bundled types define create as a TarCommand intersection with
dozens of overloads. TypeScript cannot resolve the correct overload
through sinon's generic type inference, making a plain SinonStub
incompatible with the inferred property type. This is a known
TypeScript limitation (microsoft/TypeScript#21745) affecting all
mocking libraries.
