### PR TITLE
fix(sdk): scilog.new forwards parent to LogbookMessage

### DIFF
--- a/sdk/python/scilog/scilog.py
+++ b/sdk/python/scilog/scilog.py
@@ -417,7 +417,7 @@ class SciLog:
             raise ValueError(
                 "No logbook selected. Please select a logbook before creating a message."
             )
-        msg = lm.LogbookMessage()
+        msg = lm.LogbookMessage(self)
         if text:
             msg.add_text(text)
         return msg

--- a/sdk/python/tests/test_scilog.py
+++ b/sdk/python/tests/test_scilog.py
@@ -16,6 +16,20 @@ def scilog():
     return log
 
 
+def test_new_requires_logbook():
+    log = SciLog("fake_url")
+    with pytest.raises(ValueError, match="No logbook selected"):
+        log.new("hello")
+
+
+def test_new_with_text_sets_content_and_logbook(scilog):
+    msg = scilog.new("hello")
+
+    assert isinstance(msg, LogbookMessage)
+    assert msg._logbook is scilog
+    assert msg._content.textcontent == "<p>hello</p>"
+
+
 def test_send_logbook_message(scilog):
     log = scilog
     msg = LogbookMessage()


### PR DESCRIPTION
Fixing a bug in the .new method of the SciLog SDK: The LogbookMessage object must receive the parent SciLog instance as parent, otherwise the .send command will not work. 