### PR TITLE
feat(sdk): add support for specifying the image dimensions

### DIFF
--- a/sdk/python/scilog/logbook_message.py
+++ b/sdk/python/scilog/logbook_message.py
@@ -46,18 +46,35 @@ class LogbookMessage:
         return self
 
     @typechecked
-    def add_file(self, file_path: str):
+    def add_file(
+        self, file_path: str, width: str | int | None = None, height: str | int | None = None
+    ):
         """Insert a file into the logbook message.
 
         Args:
             file_path (str): Full path to the file that ought to be added.
+            width (str | int | None): Optional width for the file display.
+            height (str | int | None): Optional height for the file display.
 
         Returns:
             LogbookMessage: The current logbook message.
         """
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File {file_path} could not be found.")
-        file_info, textcontent = SciLogCore.prepare_file_content(file_path)
+
+        def _convert_and_append(key, value: str | int) -> None:
+            if isinstance(value, int):
+                if value <= 0:
+                    raise ValueError(f"{key} must be a positive integer.")
+                value = f"{value}px"
+            dimensions[key] = value
+
+        dimensions = {}
+        if width is not None:
+            _convert_and_append("width", width)
+        if height is not None:
+            _convert_and_append("height", height)
+        file_info, textcontent = SciLogCore.prepare_file_content(file_path, **dimensions)
         if self._content.files:
             self._content.files.append(file_info)
         else:
@@ -70,7 +87,7 @@ class LogbookMessage:
         """Add tags to the logbook message.
 
         Args:
-            tag (List[str]): List of tags.
+            tag (List[str] | str): List of tags or a single tag.
 
         Returns:
             LogbookMessage: The current logbook message.

--- a/sdk/python/scilog/scilog.py
+++ b/sdk/python/scilog/scilog.py
@@ -308,7 +308,7 @@ class SciLogCore:
 
     @staticmethod
     def prepare_file_content(
-        filepath: str, fsnippet: Filesnippet | None = None
+        filepath: str, fsnippet: Filesnippet | None = None, width: str = "82.25%", height: str = ""
     ) -> Tuple[dict, str]:
         """
         Prepare file content and textcontent for appending to a snippet.
@@ -316,6 +316,8 @@ class SciLogCore:
         Args:
             filepath (str): Path to the file that ought to be prepared
             fsnippet (Filesnippet | None): Optional Filesnippet containing metadata of the file
+            width (str): Optional width for the file display (only relevant for images). Defaults to "82.25%" which corresponds to the default image width in SciLog.
+            height (str): Optional height for the file display (only relevant for images). Defaults to "" which corresponds to the default image height in SciLog.
 
         Returns:
             Tuple[dict, str]: A tuple containing the file information dictionary and the text content string
@@ -335,7 +337,7 @@ class SciLogCore:
                 "fileExtension": f"image/{file_extension}",
                 "fileId": file_id,
                 "accessHash": access_hash,
-                "style": {"width": "82.25%", "height": ""},
+                "style": {"width": width, "height": height},
             }
 
         else:

--- a/sdk/python/tests/test_scilog.py
+++ b/sdk/python/tests/test_scilog.py
@@ -74,6 +74,7 @@ def test_send_logbook_message_with_file(scilog, tmpdir):
     assert "img src" in payload["textcontent"]
     assert payload["files"][0]["fileId"] == "file1"
     assert payload["files"][0]["accessHash"] == "hash1"
+    assert payload["files"][0]["style"] == {"width": "82.25%", "height": ""}
     assert "filepath" not in payload["files"][0]
 
 
@@ -150,6 +151,40 @@ def test_prepare_file_content_image(scilog, filepath, fsnippet):
         textcontent
         == f'<figure class="image image_resized"><img src="" title="{info["fileHash"]}"></figure>'
     )
+
+
+def test_prepare_file_content_image_with_custom_dimensions(scilog):
+    log = scilog
+    info, textcontent = log.core.prepare_file_content(
+        "./test_file.png", width="640", height="480px"
+    )
+
+    assert info["style"] == {"width": "640", "height": "480px"}
+    assert (
+        textcontent
+        == f'<figure class="image image_resized"><img src="" title="{info["fileHash"]}"></figure>'
+    )
+
+
+@pytest.mark.parametrize(
+    "width,height,expected_style",
+    [
+        ("640px", "480px", {"width": "640px", "height": "480px"}),
+        (640, 480, {"width": "640px", "height": "480px"}),
+        (640, "480px", {"width": "640px", "height": "480px"}),
+    ],
+)
+def test_logbook_message_add_file_stores_dimensions(tmpdir, width, height, expected_style):
+    test_file = tmpdir.join("test_file.png")
+    test_file.write("test content")
+
+    msg = LogbookMessage()
+    msg.add_file(str(test_file), width=width, height=height)
+
+    assert msg._content.files is not None
+    assert msg._content.files[0]["filepath"] == str(test_file)
+    assert msg._content.files[0]["style"] == expected_style
+    assert '<figure class="image image_resized"><img src="" title="' in msg._content.textcontent
 
 
 @pytest.mark.parametrize("filepath,fsnippet", [("./test_file.pdf", None)])


### PR DESCRIPTION
A user requested to be able to specify the image dimensions when uploading files from BEC. Previously, the width was hard-coded to 82.25 % which remains the default but the SDK would now be able to override it. 