### PR TITLE
refactor(sci-log-db): clean up deprecated handling

### DIFF
--- a/sci-log-db/src/__tests__/acceptance/openapi-spec.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/openapi-spec.acceptance.ts
@@ -1,0 +1,39 @@
+import {expect} from '@loopback/testlab';
+import {SchemaObject} from '@loopback/rest';
+import {SciLogDbApplication} from '../..';
+import {setupApplication} from './test-helper';
+
+describe('OpenAPI spec', () => {
+  let app: SciLogDbApplication;
+  let basesnippetProps: SchemaObject['properties'];
+
+  before('setupApplication', async () => {
+    ({app} = await setupApplication());
+    const spec = await app.restServer.getApiSpec();
+    basesnippetProps = (spec.components?.schemas?.Basesnippet as SchemaObject)
+      .properties;
+  });
+
+  after(async () => {
+    await app.stop();
+  });
+
+  it('should mark ownerGroup on Basesnippet as deprecated', () => {
+    const prop = basesnippetProps!.ownerGroup as SchemaObject;
+    expect(prop.deprecated).to.be.true();
+  });
+
+  it('should mark accessGroups on Basesnippet as deprecated at the array level', () => {
+    const prop = basesnippetProps!.accessGroups as SchemaObject;
+    expect(prop.deprecated).to.be.true();
+    expect((prop.items as SchemaObject).deprecated).to.be.undefined();
+  });
+
+  it('should not mark non-deprecated properties as deprecated', () => {
+    const snippetType = basesnippetProps!.snippetType as SchemaObject;
+    expect(snippetType.deprecated).to.be.undefined();
+
+    const readACL = basesnippetProps!.readACL as SchemaObject;
+    expect(readACL.deprecated).to.be.undefined();
+  });
+});

--- a/sci-log-db/src/__tests__/unit/deprecated-spec.enhancer.unit.ts
+++ b/sci-log-db/src/__tests__/unit/deprecated-spec.enhancer.unit.ts
@@ -1,0 +1,131 @@
+import {expect} from '@loopback/testlab';
+import {OpenApiSpec, SchemaObject} from '@loopback/rest';
+import {DeprecatedSpecEnhancer} from '../../services/deprecated-spec.enhancer';
+
+describe('DeprecatedSpecEnhancer', () => {
+  const enhancer = new DeprecatedSpecEnhancer();
+
+  const baseSpec = {
+    openapi: '3.0.0',
+    info: {title: 'test', version: '1.0'},
+    paths: {
+      '/old-endpoint': {
+        get: {
+          deprecated: true,
+          responses: {'200': {description: 'OK'}},
+        },
+      },
+    },
+    components: {
+      schemas: {
+        ARef: {$ref: '#/components/schemas/Other'},
+        TestModel: {
+          properties: {
+            // deprecated array — should be hoisted
+            deprecatedArray: {
+              type: 'array',
+              items: {type: 'string', deprecated: true},
+            },
+            // deprecated: false array — should still be hoisted
+            notDeprecatedArray: {
+              type: 'array',
+              items: {type: 'string', deprecated: false},
+            },
+            // non-deprecated array — should be untouched
+            tags: {
+              type: 'array',
+              items: {type: 'string'},
+            },
+            // $ref items — should be untouched
+            subsnippets: {
+              type: 'array',
+              items: {$ref: '#/components/schemas/Other'},
+            },
+            // non-array deprecated — should be untouched
+            ownerGroup: {
+              type: 'string',
+              deprecated: true,
+            },
+          },
+        },
+        OtherModel: {
+          properties: {
+            anotherList: {
+              type: 'array',
+              items: {type: 'number', deprecated: true},
+            },
+          },
+        },
+      },
+    },
+  } as OpenApiSpec;
+
+  let props: SchemaObject['properties'];
+  let otherProps: SchemaObject['properties'];
+
+  before(() => {
+    const result = enhancer.modifySpec(structuredClone(baseSpec));
+    props = (result.components?.schemas?.TestModel as SchemaObject).properties;
+    otherProps = (result.components?.schemas?.OtherModel as SchemaObject)
+      .properties;
+  });
+
+  it('should hoist deprecated from items to array property', () => {
+    const prop = props!.deprecatedArray as SchemaObject;
+    expect(prop.deprecated).to.be.true();
+    expect((prop.items as SchemaObject).deprecated).to.be.undefined();
+  });
+
+  it('should hoist deprecated: false from items', () => {
+    const prop = props!.notDeprecatedArray as SchemaObject;
+    expect(prop.deprecated).to.be.false();
+    expect((prop.items as SchemaObject).deprecated).to.be.undefined();
+  });
+
+  it('should not modify arrays without deprecated items', () => {
+    const prop = props!.tags as SchemaObject;
+    expect(prop.deprecated).to.be.undefined();
+  });
+
+  it('should skip array items that use $ref', () => {
+    const prop = props!.subsnippets as SchemaObject;
+    expect(prop.deprecated).to.be.undefined();
+    expect(prop.items).to.eql({
+      $ref: '#/components/schemas/Other',
+    });
+  });
+
+  it('should not modify non-array deprecated properties', () => {
+    const prop = props!.ownerGroup as SchemaObject;
+    expect(prop.deprecated).to.be.true();
+  });
+
+  it('should skip schemas that are $ref only', () => {
+    const result = enhancer.modifySpec(structuredClone(baseSpec));
+    expect(result.components?.schemas?.ARef).to.eql({
+      $ref: '#/components/schemas/Other',
+    });
+  });
+
+  it('should process multiple schemas', () => {
+    const prop = otherProps!.anotherList as SchemaObject;
+    expect(prop.deprecated).to.be.true();
+    expect((prop.items as SchemaObject).deprecated).to.be.undefined();
+  });
+
+  it('should not affect deprecated endpoints', () => {
+    const result = enhancer.modifySpec(structuredClone(baseSpec));
+    expect(result.paths['/old-endpoint'].get.deprecated).to.be.true();
+  });
+
+  it('should handle spec without schemas', () => {
+    const emptySpec = {
+      openapi: '3.0.0',
+      info: {title: 'test', version: '1.0'},
+      paths: {},
+    } as OpenApiSpec;
+
+    const result = enhancer.modifySpec(emptySpec);
+    expect(result).to.eql(emptySpec);
+  });
+});

--- a/sci-log-db/src/__tests__/unit/utils.misc.unit.ts
+++ b/sci-log-db/src/__tests__/unit/utils.misc.unit.ts
@@ -3,8 +3,6 @@ import {expect} from '@loopback/testlab';
 import {Suite} from 'mocha';
 import {Basesnippet} from '../../models';
 import {
-  getModelSchemaRefWithDeprecated,
-  getModelSchemaRef,
   validateFieldsVSModel,
   defaultSequentially,
   concatOwnerAccessGroups,
@@ -114,32 +112,6 @@ describe('Utils unit tests', function (this: Suite) {
       filterEmptySubsnippets(snippet, i);
       expect(snippet).to.eql(t);
     });
-  });
-
-  it('Should add deprecated to delete', () => {
-    const withDeprecated = getModelSchemaRefWithDeprecated(Basesnippet, {
-      deprecated: ['deleted'],
-    });
-    expect(
-      Object.values(withDeprecated.definitions)[0].properties?.deleted,
-    ).to.containEql({deprecated: true});
-    expect(Basesnippet.definition.properties.deleted).not.to.containEql({
-      deprecated: true,
-    });
-  });
-
-  it('Should create a model and set ownerGroup and accessGroups to deprecated', () => {
-    const withDeprecated = getModelSchemaRef(Basesnippet);
-    expect(
-      Object.values(withDeprecated.definitions)[0].properties?.ownerGroup,
-    ).to.containEql({deprecated: true});
-    expect(
-      Object.values(withDeprecated.definitions)[0].properties?.accessGroups,
-    ).to.containEql({deprecated: true});
-    expect(Basesnippet.definition.properties.ownerGroup).not.have.keys([
-      'ownerGroup',
-      'accessGroups',
-    ]);
   });
 
   it('Should check a valid object against a model schema', () => {

--- a/sci-log-db/src/application.ts
+++ b/sci-log-db/src/application.ts
@@ -44,6 +44,7 @@ import {FileRepository, ParagraphRepository} from './repositories';
 import {MySequence} from './sequence';
 import {BcryptHasher} from './services/hash.password.bcryptjs';
 import {JWTService} from './services/jwt-service';
+import {DeprecatedSpecEnhancer} from './services/deprecated-spec.enhancer';
 import {SecuritySpecEnhancer} from './services/jwt-spec.enhancer';
 import {MyUserService} from './services/user-service';
 import {startWebsocket} from './utils/websocket';
@@ -160,6 +161,7 @@ export class SciLogDbApplication extends BootMixin(
     this.bind(UserServiceBindings.USER_SERVICE).toClass(MyUserService);
 
     this.add(createBindingFromClass(SecuritySpecEnhancer));
+    this.add(createBindingFromClass(DeprecatedSpecEnhancer));
 
     // Bind datasource config
     this.configureDatasourceFromFile(

--- a/sci-log-db/src/controllers/basesnippet.controller.ts
+++ b/sci-log-db/src/controllers/basesnippet.controller.ts
@@ -12,6 +12,7 @@ import {
 import {
   del,
   get,
+  getModelSchemaRef,
   param,
   patch,
   post,
@@ -23,7 +24,6 @@ import {SecurityBindings, UserProfile} from '@loopback/security';
 import {Basesnippet} from '../models';
 import {BasesnippetRepository} from '../repositories';
 import {basicAuthorization} from '../services/basic.authorizor';
-import {getModelSchemaRef} from '../utils/misc';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 
 @authenticate('jwt')

--- a/sci-log-db/src/controllers/file.controller.ts
+++ b/sci-log-db/src/controllers/file.controller.ts
@@ -12,6 +12,7 @@ import {
 import {
   del,
   get,
+  getModelSchemaRef,
   HttpErrors,
   modelToJsonSchema,
   param,
@@ -29,21 +30,13 @@ import _ from 'lodash';
 import {Filesnippet} from '../models/file.model';
 import {FileRepository} from '../repositories/file.repository';
 import {basicAuthorization} from '../services/basic.authorizor';
-import {
-  addOwnerGroupAccessGroups,
-  getModelSchemaRefWithStrict,
-  validateFieldsVSModel,
-} from '../utils/misc';
+import {validateFieldsVSModel} from '../utils/misc';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 
 import * as mongodb from 'mongodb';
 import crypto from 'crypto';
 
-const ownerGroupAccessGroupsFilesnippetModel = modelToJsonSchema(
-  addOwnerGroupAccessGroups(Filesnippet, true),
-);
-
-const getModelSchemaRef = getModelSchemaRefWithStrict;
+const filesnippetModel = modelToJsonSchema(Filesnippet);
 
 interface FormData {
   fields: Partial<Filesnippet>;
@@ -416,13 +409,9 @@ export class FileController {
       throw new MissingFileError();
     }
     const parsedFields = JSON.parse(fields?.fields?.[0] ?? '{}');
-    validateFieldsVSModel(
-      parsedFields,
-      ownerGroupAccessGroupsFilesnippetModel,
-      (err: unknown) => {
-        throw err;
-      },
-    );
+    validateFieldsVSModel(parsedFields, filesnippetModel, (err: unknown) => {
+      throw err;
+    });
     const file = files.file[0];
     const fileSnippet = this.addFormDataToFileSnippet(parsedFields, file);
     return {fields: fileSnippet, file};

--- a/sci-log-db/src/controllers/job.controller.ts
+++ b/sci-log-db/src/controllers/job.controller.ts
@@ -8,14 +8,21 @@ import {
   repository,
   Where,
 } from '@loopback/repository';
-import {del, get, param, patch, post, requestBody} from '@loopback/rest';
+import {
+  del,
+  get,
+  getModelSchemaRef,
+  param,
+  patch,
+  post,
+  requestBody,
+} from '@loopback/rest';
 import {Job} from '../models/job.model';
 import {JobRepository} from '../repositories/job.repository';
 import {basicAuthorization} from '../services/basic.authorizor';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 import {inject} from '@loopback/core';
-import {getModelSchemaRef} from '../utils/misc';
 
 @authenticate('jwt')
 @authorize({

--- a/sci-log-db/src/controllers/location.controller.ts
+++ b/sci-log-db/src/controllers/location.controller.ts
@@ -6,7 +6,15 @@ import {
   repository,
   Where,
 } from '@loopback/repository';
-import {post, param, get, patch, del, requestBody} from '@loopback/rest';
+import {
+  post,
+  param,
+  get,
+  getModelSchemaRef,
+  patch,
+  del,
+  requestBody,
+} from '@loopback/rest';
 import {Location} from '../models';
 import {LocationRepository} from '../repositories';
 
@@ -16,7 +24,6 @@ import {basicAuthorization} from '../services/basic.authorizor';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 import {inject} from '@loopback/core';
-import {getModelSchemaRef} from '../utils/misc';
 
 @authenticate('jwt')
 @authorize({

--- a/sci-log-db/src/controllers/logbook.controller.ts
+++ b/sci-log-db/src/controllers/logbook.controller.ts
@@ -9,12 +9,19 @@ import {
   repository,
   Where,
 } from '@loopback/repository';
-import {del, get, param, patch, post, requestBody} from '@loopback/rest';
+import {
+  del,
+  get,
+  getModelSchemaRef,
+  param,
+  patch,
+  post,
+  requestBody,
+} from '@loopback/rest';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 import {Logbook} from '../models';
 import {LogbookRepository} from '../repositories';
 import {basicAuthorization} from '../services/basic.authorizor';
-import {getModelSchemaRef} from '../utils/misc';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 
 @authenticate('jwt')

--- a/sci-log-db/src/controllers/paragraph.controller.ts
+++ b/sci-log-db/src/controllers/paragraph.controller.ts
@@ -6,7 +6,15 @@ import {
   repository,
   Where,
 } from '@loopback/repository';
-import {post, param, get, patch, del, requestBody} from '@loopback/rest';
+import {
+  post,
+  param,
+  get,
+  getModelSchemaRef,
+  patch,
+  del,
+  requestBody,
+} from '@loopback/rest';
 import {Paragraph} from '../models';
 import {ParagraphRepository} from '../repositories';
 
@@ -16,7 +24,6 @@ import {basicAuthorization} from '../services/basic.authorizor';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 import {inject} from '@loopback/core';
-import {getModelSchemaRef} from '../utils/misc';
 
 @authenticate('jwt')
 @authorize({

--- a/sci-log-db/src/controllers/task.controller.ts
+++ b/sci-log-db/src/controllers/task.controller.ts
@@ -9,12 +9,19 @@ import {
   repository,
   Where,
 } from '@loopback/repository';
-import {del, get, param, patch, post, requestBody} from '@loopback/rest';
+import {
+  del,
+  get,
+  getModelSchemaRef,
+  param,
+  patch,
+  post,
+  requestBody,
+} from '@loopback/rest';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 import {Task} from '../models';
 import {BasesnippetRepository, TaskRepository} from '../repositories';
 import {basicAuthorization} from '../services/basic.authorizor';
-import {getModelSchemaRef} from '../utils/misc';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 import {BasesnippetController} from './basesnippet.controller';
 

--- a/sci-log-db/src/controllers/view.controller.ts
+++ b/sci-log-db/src/controllers/view.controller.ts
@@ -6,10 +6,17 @@ import {
   repository,
   Where,
 } from '@loopback/repository';
-import {post, param, get, patch, del, requestBody} from '@loopback/rest';
+import {
+  post,
+  param,
+  get,
+  getModelSchemaRef,
+  patch,
+  del,
+  requestBody,
+} from '@loopback/rest';
 import {View} from '../models';
 import {ViewRepository} from '../repositories';
-import {getModelSchemaRef} from '../utils/misc';
 
 export class ViewController {
   constructor(

--- a/sci-log-db/src/models/basesnippet.model.ts
+++ b/sci-log-db/src/models/basesnippet.model.ts
@@ -84,6 +84,19 @@ export class Basesnippet extends Entity {
   })
   updatedBy: string;
 
+  @property({
+    type: 'string',
+    description: 'Deprecated. Use readACL, updateACL, etc. instead.',
+    jsonSchema: {deprecated: true},
+  })
+  ownerGroup?: string;
+
+  @property.array(String, {
+    description: 'Deprecated. Use readACL, updateACL, etc. instead.',
+    jsonSchema: {deprecated: true},
+  })
+  accessGroups?: string[];
+
   @property.array(String, {
     description: 'groups or users who can create this snippet',
     index: true,

--- a/sci-log-db/src/services/deprecated-spec.enhancer.ts
+++ b/sci-log-db/src/services/deprecated-spec.enhancer.ts
@@ -1,0 +1,36 @@
+import {injectable} from '@loopback/core';
+import {asSpecEnhancer, OASEnhancer, OpenApiSpec} from '@loopback/rest';
+
+/**
+ * A spec enhancer that hoists `deprecated: true` from array `items`
+ * to the array property level.
+ *
+ * This works around a known LoopBack 4 bug where `jsonSchema` options
+ * on array properties are merged into `items` instead of the property
+ * itself. See: https://github.com/loopbackio/loopback-next/issues/4645
+ */
+@injectable(asSpecEnhancer)
+export class DeprecatedSpecEnhancer implements OASEnhancer {
+  name = 'deprecated';
+
+  modifySpec(spec: OpenApiSpec): OpenApiSpec {
+    const schemas = spec.components?.schemas;
+    if (!schemas) return spec;
+
+    for (const schema of Object.values(schemas)) {
+      if (!('properties' in schema)) continue;
+      const properties = schema.properties ?? {};
+
+      for (const prop of Object.values(properties)) {
+        if (!('type' in prop)) continue;
+        if (prop.type !== 'array') continue;
+        if (!prop.items || !('deprecated' in prop.items)) continue;
+
+        prop.deprecated = prop.items.deprecated;
+        delete prop.items.deprecated;
+      }
+    }
+
+    return spec;
+  }
+}

--- a/sci-log-db/src/utils/misc.ts
+++ b/sci-log-db/src/utils/misc.ts
@@ -1,96 +1,8 @@
-import {
-  defineModelClass,
-  Entity,
-  JsonSchema,
-  ModelDefinition,
-  Filter,
-} from '@loopback/repository';
-import {JsonSchemaOptions} from '@loopback/repository-json-schema';
-import {
-  HttpErrors,
-  getModelSchemaRef as loobpackGetModelSchemaRef,
-  SchemaObject,
-} from '@loopback/rest';
+import {JsonSchema, Filter} from '@loopback/repository';
+import {HttpErrors} from '@loopback/rest';
 import _ from 'lodash';
 import {Basesnippet} from '../models';
 import {JSDOM} from 'jsdom';
-
-export function getModelSchemaRefWithDeprecated<T extends Entity>(
-  modelCtor: Function & {prototype: T},
-  options?: JsonSchemaOptions<T> & {deprecated?: (keyof T)[]},
-) {
-  const deprecated = options?.deprecated ?? [];
-  const stringOptions = JSON.stringify(options).replace(/[^a-zA-Z0-9 ]/g, '');
-  const title = `${options?.title ?? modelCtor.name}${stringOptions}`;
-  const modelSchemaRef = loobpackGetModelSchemaRef(modelCtor, {
-    ..._.omit(options, ['deprecated', 'title']),
-    title: title,
-  });
-  deprecated.map(d => {
-    const prop = modelSchemaRef.definitions[title].properties?.[
-      d as string
-    ] as SchemaObject;
-    if (prop) prop.deprecated = true;
-  });
-  return modelSchemaRef;
-}
-
-function getModelSchemaRefWithDeprecatedOwnerGroupAccessGroups<
-  T extends Entity,
->(
-  modelCtor: Function & {prototype: T; definition?: ModelDefinition},
-  options?: JsonSchemaOptions<T> & {strict?: boolean},
-) {
-  const snippetCompatibleSchema = addOwnerGroupAccessGroups<T>(
-    modelCtor,
-    options?.strict,
-  );
-  return getModelSchemaRefWithDeprecated(snippetCompatibleSchema, {
-    ...options,
-    deprecated: [
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      'ownerGroup' as any,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      'accessGroups' as any,
-    ],
-  });
-}
-
-export function addOwnerGroupAccessGroups<T extends Entity>(
-  modelCtor: Function & {
-    prototype: T;
-    definition?: ModelDefinition | undefined;
-  },
-  strict = false,
-) {
-  const deprecatedGroups = new ModelDefinition({
-    name: `${modelCtor.name}GroupsCompatible`,
-    settings: {
-      ..._.omit(modelCtor.definition?.settings, 'strict'),
-      strict: strict ?? modelCtor.definition?.settings?.strict,
-    },
-    properties: {
-      ownerGroup: {
-        type: 'string',
-        description:
-          'ownerGroup field is deprecated. Please create an ACL upfront and reference it through the aclId at snippet creation',
-      },
-      accessGroups: {
-        type: 'array',
-        itemType: 'string',
-        description:
-          'accessGroups field is deprecated. Please create an ACL upfront and reference it through the aclId at snippet creation',
-      },
-    },
-  });
-
-  const snippetCompatibleSchema = defineModelClass(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    modelCtor as any,
-    deprecatedGroups,
-  );
-  return snippetCompatibleSchema;
-}
 
 export const validateFieldsVSModel = (
   fields: object,
@@ -119,18 +31,6 @@ export const validateFieldsVSModel = (
     return error;
   }
 };
-
-export const getModelSchemaRef =
-  getModelSchemaRefWithDeprecatedOwnerGroupAccessGroups;
-export function getModelSchemaRefWithStrict<T extends Entity>(
-  modelCtor: Function & {prototype: T; definition?: ModelDefinition},
-  options?: JsonSchemaOptions<T> & {strict?: boolean},
-) {
-  return getModelSchemaRefWithDeprecatedOwnerGroupAccessGroups(modelCtor, {
-    ..._.omit(options, 'strict'),
-    strict: true,
-  });
-}
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export function defaultSequentially(...args: any[]) {


### PR DESCRIPTION
Removes runtime schema manipulation from misc.ts
that dynamically injected ownerGroup/accessGroups into the
OpenAPI spec using synthetic subclasses and as-any casts.

Replaced with simple @property annotations on Basesnippet and
a DeprecatedSpecEnhancer to work around loopbackio/loopback-next#4645

Controllers now import getModelSchemaRef directly from
@loopback/rest instead of a custom wrapper, making the code
easier to follow and the deprecation intent visible on the
model where it belongs.

Close: #543
See: DATACGRP-611
