### PR TITLE
fix(api): add missing ws dependency

### DIFF
--- a/sci-log-db/package-lock.json
+++ b/sci-log-db/package-lock.json
@@ -33,7 +33,8 @@
         "ro-crate": "3.6.1",
         "ro-crate-html": "0.1.6",
         "tar": "7.5.13",
-        "tslib": "2.0.0"
+        "tslib": "2.0.0",
+        "ws": "8.20.0"
       },
       "devDependencies": {
         "@loopback/build": "12.0.10",
@@ -47,6 +48,7 @@
         "@types/node": "16.18.126",
         "@types/passport": "1.0.17",
         "@types/prismjs": "1.26.6",
+        "@types/ws": "8.18.1",
         "eslint": "8.57.1",
         "source-map-support": "0.5.21",
         "tsc-watch": "5.0.3",
@@ -4095,6 +4097,16 @@
       "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/yauzl": {
@@ -10840,27 +10852,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
@@ -13025,6 +13016,27 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/sci-log-db/package.json
+++ b/sci-log-db/package.json
@@ -72,7 +72,8 @@
     "ro-crate": "3.6.1",
     "ro-crate-html": "0.1.6",
     "tar": "7.5.13",
-    "tslib": "2.0.0"
+    "tslib": "2.0.0",
+    "ws": "8.20.0"
   },
   "devDependencies": {
     "@loopback/build": "12.0.10",
@@ -86,6 +87,7 @@
     "@types/node": "16.18.126",
     "@types/passport": "1.0.17",
     "@types/prismjs": "1.26.6",
+    "@types/ws": "8.18.1",
     "eslint": "8.57.1",
     "source-map-support": "0.5.21",
     "tsc-watch": "5.0.3",


### PR DESCRIPTION
ws is imported in websocket.ts but was never declared as a
direct dependency — it resolved transitively through pm2.
After pm2 was removed in 3baebfe, clean installs fail with
MODULE_NOT_FOUND.

Close: #567
