### PR TITLE
fix: revert to workdir for backward compatibility

### DIFF
--- a/sci-log-db/Dockerfile
+++ b/sci-log-db/Dockerfile
@@ -75,8 +75,8 @@ FROM base AS production
 ENV NODE_ENV=production
 
 COPY --chown=node:node package*.json ./
-COPY --from=prod-deps --chown=node:node node_modules ./node_modules
-COPY --from=build --chown=node:node dist ./dist
+COPY --from=prod-deps --chown=node:node /home/node/app/node_modules ./node_modules
+COPY --from=build --chown=node:node /home/node/app/dist ./dist
 
 USER node
 

--- a/sci-log-db/Dockerfile
+++ b/sci-log-db/Dockerfile
@@ -4,9 +4,9 @@
 # (required for PDF export, even in production).
 FROM node:22.22.2-slim AS base
 
-WORKDIR /app
+WORKDIR /home/node/app
 
-RUN chown -R node:node /app
+RUN chown -R node:node .
 
 RUN apt-get update && \
     apt-get install -y chromium --no-install-recommends && \
@@ -75,8 +75,8 @@ FROM base AS production
 ENV NODE_ENV=production
 
 COPY --chown=node:node package*.json ./
-COPY --from=prod-deps --chown=node:node /app/node_modules ./node_modules
-COPY --from=build --chown=node:node /app/dist ./dist
+COPY --from=prod-deps --chown=node:node node_modules ./node_modules
+COPY --from=build --chown=node:node dist ./dist
 
 USER node
 

--- a/sci-log-db/compose.yaml
+++ b/sci-log-db/compose.yaml
@@ -32,8 +32,8 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - .:/app
-      - node_modules:/app/node_modules
+      - .:/home/node/app
+      - node_modules:/home/node/app/node_modules
     tty: true
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3000/api/v1').then(r => { if (!r.ok) throw r.status })"]
@@ -65,8 +65,8 @@ services:
       JWT_SECRET: my-super-secret-key
       BASE_PATH: /api/v1
     volumes:
-      - ./datasource.json:/app/datasource.json:ro
-      - ./oidc.json:/app/oidc.json:ro
+      - ./datasource.json:/home/node/app/datasource.json:ro
+      - ./oidc.json:/home/node/app/oidc.json:ro
     profiles: [production]
 
 volumes:


### PR DESCRIPTION
Revert to /home/node/app for backward compatibility. This is favoured compared to changing the volume mounts to avoid a breaking change for other adopters