### PR TITLE
refactor(api): preserve logbook name in ELN export

### DIFF
--- a/sci-log-db/src/__tests__/unit/service.ro-crate-export.unit.ts
+++ b/sci-log-db/src/__tests__/unit/service.ro-crate-export.unit.ts
@@ -77,7 +77,7 @@ describe('RoCrateExportService (unit)', () => {
       entityBuilder.getEntityId('logbook-1'),
     );
     // expect logbook name/description to match
-    expect(logbookEntity.name).to.equal('SciLog ELN export: Test Logbook');
+    expect(logbookEntity.name).to.equal('Test Logbook');
     expect(logbookEntity.description).to.equal('A logbook for testing');
     // expect hasPart to contain three snippets: two paragraphs and a comment
     expect(logbookEntity.hasPart).to.be.Array();

--- a/sci-log-db/src/services/entity-builder.service.ts
+++ b/sci-log-db/src/services/entity-builder.service.ts
@@ -52,7 +52,7 @@ export class EntityBuilderService {
       '@id': this.getEntityId(logbook.id),
       '@type': ['Book', 'Dataset'],
       genre: 'experiment',
-      name: `SciLog ELN export: ${logbook.name}`,
+      name: logbook.name,
       description: logbook.description ?? '',
       dateCreated: logbook.createdAt?.toISOString(),
       author,


### PR DESCRIPTION
Drop the "SciLog ELN export: " prefix from the RO-Crate logbook
entity name. Export should faithfully represent the user's data,
not silently rewrite it.
