### PR TITLE
fix: use types from ro-crate library

### DIFF
--- a/sci-log-db/package-lock.json
+++ b/sci-log-db/package-lock.json
@@ -29,7 +29,7 @@
         "pdf-merger-js": "4.3.1",
         "prismjs": "1.30.0",
         "puppeteer": "24.39.1",
-        "ro-crate": "3.6.1",
+        "ro-crate": "3.7.1",
         "ro-crate-html": "0.1.6",
         "tar": "7.5.13",
         "tslib": "2.0.0",
@@ -10992,9 +10992,9 @@
       }
     },
     "node_modules/ro-crate": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/ro-crate/-/ro-crate-3.6.1.tgz",
-      "integrity": "sha512-nKXWiJyG4uK0koTbpZXaeCfsfrikoQM5e9nqZPXWXsFAVT+EZDDszQE6Nw2djTdPLcz/cdNJ9r1d0vt+s3NhqQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/ro-crate/-/ro-crate-3.7.1.tgz",
+      "integrity": "sha512-eFmna6D8OoEmZ25MZnQ6w9hu477Da6j1/ZU3WsBWHLwej2qo4V0qy1KmXo5wpiLoqrIMr7Jbss9JmpKW/kc/Jg==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "commander": "^12.0.0",

--- a/sci-log-db/package.json
+++ b/sci-log-db/package.json
@@ -61,7 +61,7 @@
     "pdf-merger-js": "4.3.1",
     "prismjs": "1.30.0",
     "puppeteer": "24.39.1",
-    "ro-crate": "3.6.1",
+    "ro-crate": "3.7.1",
     "ro-crate-html": "0.1.6",
     "tar": "7.5.13",
     "tslib": "2.0.0",

--- a/sci-log-db/src/__tests__/acceptance/ro-crate.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/ro-crate.controller.acceptance.ts
@@ -5,8 +5,6 @@ import {clearDatabase, createUserToken, setupApplication} from './test-helper';
 import {DatabaseHelper} from '../database.helpers';
 import fs from 'fs';
 import yauzl from 'yauzl';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import {ROCrate} from 'ro-crate';
 import {pipeline, Readable} from 'stream';
 import {RoCrateController} from '../../controllers';

--- a/sci-log-db/src/services/ro-crate-export.service.ts
+++ b/sci-log-db/src/services/ro-crate-export.service.ts
@@ -11,8 +11,6 @@ import {Filesnippet} from '../models/file.model';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 
 import {RawEntity} from 'ro-crate/lib/types';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import {ROCrate} from 'ro-crate';
 
 export interface FileMetadata {
@@ -62,7 +60,7 @@ export class RoCrateExportService {
     this.crate.root.description = logbook.description ?? '';
     this.crate.root.license = this.entityBuilder.buildLicenseEntity();
     this.crate.root.datePublished = new Date().toISOString();
-    this.crate.metadata.sdPublisher =
+    this.crate.descriptor.sdPublisher =
       this.entityBuilder.buildOrganizationEntity();
     this.crate.root.hasPart = [];
 


### PR DESCRIPTION
We enabled type declarations upstream in the `ro-crate` library ([PR](https://github.com/Language-Research-Technology/ro-crate-js/pull/30)). 
Upgrading to v3.7.1 of the lib which includes them. 
Moreover rocrate.metadata was a type error (but somehow still working), replaced it with [descriptor](https://language-research-technology.github.io/ro-crate-js/v3.7/classes/ROCrate.html#descriptor) instead.