### PR TITLE
chore: fix tsconfig.json setup for TS language server

### DIFF
--- a/scilog/tsconfig.app.json
+++ b/scilog/tsconfig.app.json
@@ -2,20 +2,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "",
-    "paths": {
-      "@model/*": ["src/app/core/model/*"],
-      "@shared/*": [
-        "src/app/core/*",
-        "src/app/logbook/core/*",
-        "src/app/overview/core/*",
-        "src/app/login/core/*"
-      ],
-      "@widgets/*": ["src/app/core/logbook/widgets/*"]
-    },
-    "outDir": "./out-tsc/app",
     "types": []
   },
-  "files": ["src/main.ts", "src/polyfills.ts"],
-  "include": ["src/ **/.d.ts", "src/ **/*.ts"]
+  "files": ["src/main.ts", "src/polyfills.ts"]
 }

--- a/scilog/tsconfig.json
+++ b/scilog/tsconfig.json
@@ -13,6 +13,16 @@
     "target": "ES2022",
     "module": "es2020",
     "lib": ["es2020", "dom"],
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    "paths": {
+      "@model/*": ["src/app/core/model/*"],
+      "@shared/*": [
+        "src/app/core/*",
+        "src/app/logbook/core/*",
+        "src/app/overview/core/*",
+        "src/app/login/core/*"
+      ],
+      "@widgets/*": ["src/app/core/logbook/widgets/*"]
+    }
   }
 }

--- a/scilog/tsconfig.spec.json
+++ b/scilog/tsconfig.spec.json
@@ -2,18 +2,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "",
-    "paths": {
-      "@model/*": ["src/app/core/model/*"],
-      "@shared/*": [
-        "src/app/core/*",
-        "src/app/logbook/core/*",
-        "src/app/overview/core/*",
-        "src/app/login/core/*"
-      ],
-      "@widgets/*": ["src/app/core/logbook/widgets/*"]
-    },
-    "outDir": "./out-tsc/spec",
     "types": ["jasmine"]
   },
   "files": ["src/test.ts", "src/polyfills.ts"],


### PR DESCRIPTION
When developing SciLog frontend in VSCode, the TS language server ignores `tsconfig.app.json`, so module resolution fails in most ts files. (It's not a problem for angular build (`ng build`), as it uses uses tsconfig.app.json as entrypoint in [angular.json](https://github.com/paulscherrerinstitute/scilog/blob/main/scilog/angular.json#L25))

Move the `paths` from .spec and .app configs to the base `tsconfig.json`. Remove some unused configs e.g. `baseUrl` and the broken `include` config from .app. 
`tsc` now runs without errors.

(I've already been using these settings for a year. Figured better to commit them than have them lying around in working tree locally)