### PR TITLE
refactor(api): add ELN metadata validator

### DIFF
--- a/sci-log-db/src/__tests__/eln.helpers.ts
+++ b/sci-log-db/src/__tests__/eln.helpers.ts
@@ -1,0 +1,50 @@
+import {ROCrate} from 'ro-crate';
+
+// Minimal RO-Crate 1.2 + ELN graph that passes validation.
+export function validElnCrate(): ROCrate {
+  return new ROCrate(
+    {
+      '@context': 'https://w3id.org/ro/crate/1.2/context',
+      '@graph': [
+        {
+          '@id': 'ro-crate-metadata.json',
+          '@type': 'CreativeWork',
+          identifier: 'ro-crate-metadata.json',
+          about: {
+            '@id': './',
+          },
+          conformsTo: {
+            '@id': 'https://w3id.org/ro/crate/1.2',
+          },
+          sdPublisher: {
+            '@id': 'https://github.com/paulscherrerinstitute/scilog',
+          },
+        },
+        {
+          '@id': './',
+          '@type': 'Dataset',
+          name: 'crate',
+          author: {'@id': '#author'},
+          hasPart: [{'@id': './book/'}],
+        },
+        {
+          '@id': 'https://github.com/paulscherrerinstitute/scilog',
+          '@type': 'Organization',
+          name: 'SciLog',
+          url: 'https://github.com/paulscherrerinstitute/scilog',
+        },
+        {'@id': '#author', '@type': 'Person', email: 'a@example.org'},
+        {
+          '@id': './book/',
+          '@type': ['Book', 'Dataset'],
+          name: 'book',
+          description: 'a book',
+          dateCreated: '2026-01-19T00:00:00.000Z',
+          author: {'@id': '#author'},
+          hasPart: [],
+        },
+      ],
+    },
+    {array: true},
+  );
+}

--- a/sci-log-db/src/__tests__/unit/eln-validator.unit.ts
+++ b/sci-log-db/src/__tests__/unit/eln-validator.unit.ts
@@ -1,0 +1,263 @@
+import {expect} from '@loopback/testlab';
+import {validElnCrate} from '../eln.helpers';
+import {ElnErrorCode, validateElnMetadata} from '../../services/eln-validator';
+
+describe('eln-validator', () => {
+  it('accepts a minimal valid metadata object', () => {
+    expect(validateElnMetadata(validElnCrate())).to.be.empty();
+  });
+
+  it('rejects when sdPublisher is not a supported publisher', () => {
+    const crate = validElnCrate();
+    crate.setProperty('ro-crate-metadata.json', 'sdPublisher', {
+      '@id': 'https://example.org/unknown-eln',
+    });
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_PUBLISHER},
+    ]);
+  });
+
+  it('rejects when sdPublisher is missing', () => {
+    const crate = validElnCrate();
+    crate.deleteProperty('ro-crate-metadata.json', 'sdPublisher');
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.MISSING_ELN_FIELD},
+    ]);
+  });
+
+  it('rejects when sdPublisher entity is not found in crate', () => {
+    const crate = validElnCrate();
+    const id = 'https://github.com/paulscherrerinstitute/scilog';
+    crate.deleteEntity(id);
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_PUBLISHER},
+    ]);
+  });
+
+  it('rejects when sdPublisher entity is not an Organization', () => {
+    const crate = validElnCrate();
+    const id = 'https://github.com/paulscherrerinstitute/scilog';
+    crate.setProperty(id, '@type', 'Person');
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_PUBLISHER},
+    ]);
+  });
+
+  it('rejects when sdPublisher entity is missing name', () => {
+    const crate = validElnCrate();
+    const id = 'https://github.com/paulscherrerinstitute/scilog';
+    crate.deleteProperty(id, 'name');
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_PUBLISHER},
+    ]);
+  });
+
+  it('rejects when sdPublisher entity is missing url', () => {
+    const crate = validElnCrate();
+    const id = 'https://github.com/paulscherrerinstitute/scilog';
+    crate.deleteProperty(id, 'url');
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_PUBLISHER},
+    ]);
+  });
+
+  it('rejects when conformsTo is missing from descriptor', () => {
+    const crate = validElnCrate();
+    crate.deleteProperty('ro-crate-metadata.json', 'conformsTo');
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.MISSING_ELN_FIELD},
+    ]);
+  });
+
+  it('rejects when conformsTo is below RO-Crate 1.1', () => {
+    const crate = validElnCrate();
+    crate.setProperty('ro-crate-metadata.json', 'conformsTo', {
+      '@id': 'https://w3id.org/ro/crate/1.0',
+    });
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_CONFORMS_TO},
+    ]);
+  });
+
+  it('rejects when a File entity is missing name', () => {
+    const crate = validElnCrate();
+    crate.addEntity({
+      '@id': './book/img.jpg',
+      '@type': 'File',
+      encodingFormat: 'image/jpeg',
+      contentSize: '123',
+      sha256: '0'.repeat(64),
+    });
+    crate.addValues('./book/', 'hasPart', {'@id': './book/img.jpg'});
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.MISSING_FILE_FIELD},
+    ]);
+  });
+
+  it('rejects when a File entity is missing encodingFormat', () => {
+    const crate = validElnCrate();
+    crate.addEntity({
+      '@id': './book/img.jpg',
+      '@type': 'File',
+      name: 'img.jpg',
+      contentSize: '123',
+      sha256: '0'.repeat(64),
+    });
+    crate.addValues('./book/', 'hasPart', {'@id': './book/img.jpg'});
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.MISSING_FILE_FIELD},
+    ]);
+  });
+
+  it('rejects when a File entity is missing sha256', () => {
+    const crate = validElnCrate();
+    crate.addEntity({
+      '@id': './book/img.jpg',
+      '@type': 'File',
+      name: 'img.jpg',
+      encodingFormat: 'image/jpeg',
+      contentSize: '123',
+    });
+    crate.addValues('./book/', 'hasPart', {'@id': './book/img.jpg'});
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.MISSING_FILE_FIELD},
+    ]);
+  });
+
+  it('rejects when a File entity is missing contentSize', () => {
+    const crate = validElnCrate();
+    crate.addEntity({
+      '@id': './book/img.jpg',
+      '@type': 'File',
+      name: 'img.jpg',
+      encodingFormat: 'image/jpeg',
+      sha256: '0'.repeat(64),
+    });
+    crate.addValues('./book/', 'hasPart', {'@id': './book/img.jpg'});
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.MISSING_FILE_FIELD},
+    ]);
+  });
+
+  it('rejects when a Dataset entity is missing author', () => {
+    const crate = validElnCrate();
+    crate.deleteProperty('./book/', 'author');
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.MISSING_DATASET_FIELD},
+    ]);
+  });
+
+  it('rejects when a Dataset entity is missing name', () => {
+    const crate = validElnCrate();
+    crate.deleteProperty('./book/', 'name');
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.MISSING_DATASET_FIELD},
+    ]);
+  });
+
+  it('rejects when author entity is not found', () => {
+    const crate = validElnCrate();
+    crate.setProperty('./book/', 'author', {'@id': '#nonexistent'});
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_AUTHOR},
+    ]);
+  });
+
+  it('rejects when author entity is not a Person', () => {
+    const crate = validElnCrate();
+    crate.setProperty('#author', '@type', 'Organization');
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_AUTHOR},
+    ]);
+  });
+
+  it('rejects when author entity is missing email', () => {
+    const crate = validElnCrate();
+    crate.deleteProperty('#author', 'email');
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_AUTHOR},
+    ]);
+  });
+
+  it('rejects when hasPart references a non-existent entity', () => {
+    const crate = validElnCrate();
+    crate.addValues('./book/', 'hasPart', {'@id': './does-not-exist/'});
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_HAS_PART},
+    ]);
+  });
+
+  it('accepts numeric contentSize', () => {
+    const crate = validElnCrate();
+    crate.addEntity({
+      '@id': './book/img.jpg',
+      '@type': 'File',
+      name: 'img.jpg',
+      encodingFormat: 'image/jpeg',
+      contentSize: 123,
+      sha256: '0'.repeat(64),
+    });
+    crate.addValues('./book/', 'hasPart', {'@id': './book/img.jpg'});
+    expect(validateElnMetadata(crate)).to.be.empty();
+  });
+
+  it('rejects contentSize with unit suffixes', () => {
+    const crate = validElnCrate();
+    crate.addEntity({
+      '@id': './book/img.jpg',
+      '@type': 'File',
+      name: 'img.jpg',
+      encodingFormat: 'image/jpeg',
+      contentSize: '2.5MB',
+    });
+    crate.addValues('./book/', 'hasPart', {'@id': './book/img.jpg'});
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_CONTENT_SIZE},
+    ]);
+  });
+
+  it('rejects contentSize that is non-numeric', () => {
+    const crate = validElnCrate();
+    crate.addEntity({
+      '@id': './book/img.jpg',
+      '@type': 'File',
+      name: 'img.jpg',
+      encodingFormat: 'image/jpeg',
+      contentSize: 'abc',
+    });
+    crate.addValues('./book/', 'hasPart', {'@id': './book/img.jpg'});
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_CONTENT_SIZE},
+    ]);
+  });
+
+  it('rejects contentSize that is negative', () => {
+    const crate = validElnCrate();
+    crate.addEntity({
+      '@id': './book/img.jpg',
+      '@type': 'File',
+      name: 'img.jpg',
+      encodingFormat: 'image/jpeg',
+      contentSize: '-5',
+    });
+    crate.addValues('./book/', 'hasPart', {'@id': './book/img.jpg'});
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_CONTENT_SIZE},
+    ]);
+  });
+
+  it('rejects contentSize that is empty', () => {
+    const crate = validElnCrate();
+    crate.addEntity({
+      '@id': './book/img.jpg',
+      '@type': 'File',
+      name: 'img.jpg',
+      encodingFormat: 'image/jpeg',
+      contentSize: '',
+    });
+    crate.addValues('./book/', 'hasPart', {'@id': './book/img.jpg'});
+    expect(validateElnMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_CONTENT_SIZE},
+    ]);
+  });
+});

--- a/sci-log-db/src/services/eln-validator.ts
+++ b/sci-log-db/src/services/eln-validator.ts
@@ -1,0 +1,253 @@
+/**
+ * .eln (RO-Crate 1.1+) metadata validator.
+ * Contract pinned by `__tests__/unit/eln-validator.unit.ts`.
+ *
+ * Spec: https://github.com/TheELNConsortium/TheELNFileFormat/blob/master/SPECIFICATION.md
+ */
+
+import {ROCrate} from 'ro-crate';
+
+/**
+ * Error codes emitted by the .eln validator.
+ * One entry per distinct MUST/SHOULD clause we enforce; see the
+ * spec link above for the prose behind each code.
+ */
+export const ElnErrorCode = {
+  MISSING_ELN_FIELD: 'MISSING_ELN_FIELD',
+  INVALID_CONFORMS_TO: 'INVALID_CONFORMS_TO',
+  INVALID_PUBLISHER: 'INVALID_PUBLISHER',
+  MISSING_FILE_FIELD: 'MISSING_FILE_FIELD',
+  MISSING_DATASET_FIELD: 'MISSING_DATASET_FIELD',
+  INVALID_AUTHOR: 'INVALID_AUTHOR',
+  INVALID_HAS_PART: 'INVALID_HAS_PART',
+  INVALID_CONTENT_SIZE: 'INVALID_CONTENT_SIZE',
+} as const;
+
+export type ElnErrorCode = (typeof ElnErrorCode)[keyof typeof ElnErrorCode];
+
+export interface ElnValidationError {
+  code: ElnErrorCode;
+  message: string;
+}
+
+const SUPPORTED_PUBLISHERS = [
+  'https://github.com/paulscherrerinstitute/scilog',
+];
+
+const SUPPORTED_RO_CRATE_VERSIONS = [
+  'https://w3id.org/ro/crate/1.1',
+  'https://w3id.org/ro/crate/1.2',
+];
+
+export function validateElnMetadata(crate: ROCrate): ElnValidationError[] {
+  return [
+    ...validateConformsTo(crate),
+    ...validateSdPublisher(crate),
+    ...validateDatasets(crate),
+    ...validateAuthors(crate),
+    ...validateFiles(crate),
+    ...validateHasPartReferences(crate),
+  ];
+}
+
+function validateConformsTo(crate: ROCrate): ElnValidationError[] {
+  const conformsTo = crate.descriptor.conformsTo;
+  if (!conformsTo?.length) {
+    return [
+      {
+        code: ElnErrorCode.MISSING_ELN_FIELD,
+        message: 'Missing conformsTo',
+      },
+    ];
+  }
+
+  const id = conformsTo[0]?.['@id'];
+  if (!SUPPORTED_RO_CRATE_VERSIONS.includes(id)) {
+    return [
+      {
+        code: ElnErrorCode.INVALID_CONFORMS_TO,
+        message: `Unsupported conformsTo: ${id}`,
+      },
+    ];
+  }
+  return [];
+}
+
+function validateSdPublisher(crate: ROCrate): ElnValidationError[] {
+  const sdPublisher = crate.descriptor.sdPublisher;
+  if (!sdPublisher?.length) {
+    return [
+      {
+        code: ElnErrorCode.MISSING_ELN_FIELD,
+        message: 'Missing sdPublisher',
+      },
+    ];
+  }
+
+  const id = sdPublisher[0]?.['@id'];
+  if (!SUPPORTED_PUBLISHERS.includes(id)) {
+    return [
+      {
+        code: ElnErrorCode.INVALID_PUBLISHER,
+        message: `Unsupported sdPublisher: ${id}`,
+      },
+    ];
+  }
+
+  const publisher = crate.getEntity(id);
+  if (!publisher) {
+    return [
+      {
+        code: ElnErrorCode.INVALID_PUBLISHER,
+        message: `sdPublisher: entity ${id} not found`,
+      },
+    ];
+  }
+
+  const errors: ElnValidationError[] = [];
+  const types = publisher['@type'] as string[];
+  if (!types.includes('Organization')) {
+    errors.push({
+      code: ElnErrorCode.INVALID_PUBLISHER,
+      message: `sdPublisher ${id}: must be an Organization`,
+    });
+  }
+  if (!publisher.name?.length) {
+    errors.push({
+      code: ElnErrorCode.INVALID_PUBLISHER,
+      message: `sdPublisher ${id}: missing name`,
+    });
+  }
+  if (!publisher.url?.length) {
+    errors.push({
+      code: ElnErrorCode.INVALID_PUBLISHER,
+      message: `sdPublisher ${id}: missing url`,
+    });
+  }
+  return errors;
+}
+
+function validateDatasets(crate: ROCrate): ElnValidationError[] {
+  const errors: ElnValidationError[] = [];
+  for (const entity of crate.entities()) {
+    const types = entity['@type'] as string[];
+    if (!types.includes('Dataset')) continue;
+
+    if (!entity.name?.length) {
+      errors.push({
+        code: ElnErrorCode.MISSING_DATASET_FIELD,
+        message: `Dataset ${entity['@id']}: missing name`,
+      });
+    }
+    if (!entity.author?.length) {
+      errors.push({
+        code: ElnErrorCode.MISSING_DATASET_FIELD,
+        message: `Dataset ${entity['@id']}: missing author`,
+      });
+    }
+  }
+  return errors;
+}
+
+function validateAuthors(crate: ROCrate): ElnValidationError[] {
+  const errors: ElnValidationError[] = [];
+  for (const entity of crate.entities()) {
+    const author = entity.author;
+    if (!author?.length) continue;
+
+    for (const ref of author) {
+      const id = ref['@id'];
+      const person = crate.getEntity(id);
+      if (!person) {
+        errors.push({
+          code: ElnErrorCode.INVALID_AUTHOR,
+          message: `author: entity ${id} not found`,
+        });
+        continue;
+      }
+
+      const types = person['@type'] as string[];
+      if (!types.includes('Person')) {
+        errors.push({
+          code: ElnErrorCode.INVALID_AUTHOR,
+          message: `author ${id}: must be a Person`,
+        });
+      }
+      if (!person.email?.length) {
+        errors.push({
+          code: ElnErrorCode.INVALID_AUTHOR,
+          message: `author ${id}: missing email`,
+        });
+      }
+    }
+  }
+  return errors;
+}
+
+function validateFiles(crate: ROCrate): ElnValidationError[] {
+  const errors: ElnValidationError[] = [];
+  for (const entity of crate.entities()) {
+    const types = entity['@type'] as string[];
+    if (!types.includes('File')) continue;
+
+    if (!entity.name?.length) {
+      errors.push({
+        code: ElnErrorCode.MISSING_FILE_FIELD,
+        message: `File ${entity['@id']}: missing name`,
+      });
+    }
+    if (!entity.encodingFormat?.length) {
+      errors.push({
+        code: ElnErrorCode.MISSING_FILE_FIELD,
+        message: `File ${entity['@id']}: missing encodingFormat`,
+      });
+    }
+    if (!entity.sha256?.length) {
+      errors.push({
+        code: ElnErrorCode.MISSING_FILE_FIELD,
+        message: `File ${entity['@id']}: missing sha256`,
+      });
+    }
+
+    if (!entity.contentSize?.length) {
+      errors.push({
+        code: ElnErrorCode.MISSING_FILE_FIELD,
+        message: `File ${entity['@id']}: missing contentSize`,
+      });
+      continue;
+    }
+    const contentSize = entity.contentSize[0];
+    if (!isValidContentSize(contentSize)) {
+      errors.push({
+        code: ElnErrorCode.INVALID_CONTENT_SIZE,
+        message: `File ${entity['@id']}: invalid contentSize "${contentSize}"`,
+      });
+    }
+  }
+  return errors;
+}
+
+function isValidContentSize(value: string | number): boolean {
+  if (value === '') return false;
+  const num = Number(value);
+  return Number.isInteger(num) && num >= 0;
+}
+
+function validateHasPartReferences(crate: ROCrate): ElnValidationError[] {
+  const errors: ElnValidationError[] = [];
+  for (const entity of crate.entities()) {
+    const hasPart = entity.hasPart;
+    if (!hasPart?.length) continue;
+
+    for (const ref of hasPart) {
+      const id = ref['@id'];
+      if (!crate.getEntity(id)) {
+        errors.push({
+          code: ElnErrorCode.INVALID_HAS_PART,
+          message: `Entity ${entity['@id']}: hasPart ${id} not found`,
+        });
+      }
+    }
+  }
+  return errors;
+}


### PR DESCRIPTION
Catch malformed or unsupported .eln archives early, before they
propagate bad data into SciLog during import. Validating upfront
lets us surface clear, actionable errors to the user instead of
silent failures or corrupt logbook entries downstream.
