### PR TITLE
feat(tag-editor): enable inline editing of tags

### DIFF
--- a/scilog/src/app/logbook/core/tag-editor/tag-editor.component.html
+++ b/scilog/src/app/logbook/core/tag-editor/tag-editor.component.html
@@ -14,15 +14,13 @@
   </button>
   <mat-form-field [floatLabel]="'auto'" subscriptSizing="dynamic">
     <mat-chip-grid #chipList aria-label="Tag selection">
-      <mat-chip-row
-        *ngFor="let tagItem of tag; let i = index"
-        (removed)="remove(tagItem)"
-      >
+      <mat-chip-row *ngFor="let tagItem of tag; let i = index" (removed)="remove(tagItem)">
         <input
           [(ngModel)]="tagItem.name"
           (blur)="tagsUpdate.emit(tagsToStrings(this.tag))"
-          style="border:none; background:transparent; width:80px"
+          style="border: none; background: transparent; width: 80px"
         />
+
         <button matChipRemove>
           <mat-icon>cancel</mat-icon>
         </button>

--- a/scilog/src/app/logbook/core/tag-editor/tag-editor.component.html
+++ b/scilog/src/app/logbook/core/tag-editor/tag-editor.component.html
@@ -14,15 +14,21 @@
   </button>
   <mat-form-field [floatLabel]="'auto'" subscriptSizing="dynamic">
     <mat-chip-grid #chipList aria-label="Tag selection">
-      <mat-chip-row
-        *ngFor="let tagItem of tag"
-        [removable]="removable"
-        (removed)="remove(tagItem)"
-        class="tag"
-      >
-        {{ tagItem.name }}
-        <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
-      </mat-chip-row>
+    <mat-chip-row
+  *ngFor="let tagItem of tag; let i = index"
+  (removed)="remove(tagItem)">
+
+  <input
+    [(ngModel)]="tagItem.name"
+    (blur)="tagsUpdate.emit(tagsToStrings(this.tag))"
+    style="border:none; background:transparent; width:80px"
+  />
+
+  <button matChipRemove>
+    <mat-icon>cancel</mat-icon>
+  </button>
+
+</mat-chip-row>
       <input
         matInput
         placeholder="Add tags"

--- a/scilog/src/app/logbook/core/tag-editor/tag-editor.component.html
+++ b/scilog/src/app/logbook/core/tag-editor/tag-editor.component.html
@@ -14,21 +14,19 @@
   </button>
   <mat-form-field [floatLabel]="'auto'" subscriptSizing="dynamic">
     <mat-chip-grid #chipList aria-label="Tag selection">
-    <mat-chip-row
-  *ngFor="let tagItem of tag; let i = index"
-  (removed)="remove(tagItem)">
-
-  <input
-    [(ngModel)]="tagItem.name"
-    (blur)="tagsUpdate.emit(tagsToStrings(this.tag))"
-    style="border:none; background:transparent; width:80px"
-  />
-
-  <button matChipRemove>
-    <mat-icon>cancel</mat-icon>
-  </button>
-
-</mat-chip-row>
+      <mat-chip-row
+        *ngFor="let tagItem of tag; let i = index"
+        (removed)="remove(tagItem)"
+      >
+        <input
+          [(ngModel)]="tagItem.name"
+          (blur)="tagsUpdate.emit(tagsToStrings(this.tag))"
+          style="border:none; background:transparent; width:80px"
+        />
+        <button matChipRemove>
+          <mat-icon>cancel</mat-icon>
+        </button>
+      </mat-chip-row>
       <input
         matInput
         placeholder="Add tags"

--- a/web/src/app/logbook/core/tag-editor/tag-editor.component.html
+++ b/web/src/app/logbook/core/tag-editor/tag-editor.component.html
@@ -14,15 +14,13 @@
   </button>
   <mat-form-field [floatLabel]="'auto'" subscriptSizing="dynamic">
     <mat-chip-grid #chipList aria-label="Tag selection">
-      <mat-chip-row
-        *ngFor="let tagItem of tag; let i = index"
-        (removed)="remove(tagItem)"
-      >
+      <mat-chip-row *ngFor="let tagItem of tag; let i = index" (removed)="remove(tagItem)">
         <input
           [(ngModel)]="tagItem.name"
           (blur)="tagsUpdate.emit(tagsToStrings(this.tag))"
-          style="border:none; background:transparent; width:80px"
+          style="border: none; background: transparent; width: 80px"
         />
+
         <button matChipRemove>
           <mat-icon>cancel</mat-icon>
         </button>

--- a/web/src/app/logbook/core/tag-editor/tag-editor.component.html
+++ b/web/src/app/logbook/core/tag-editor/tag-editor.component.html
@@ -14,15 +14,21 @@
   </button>
   <mat-form-field [floatLabel]="'auto'" subscriptSizing="dynamic">
     <mat-chip-grid #chipList aria-label="Tag selection">
-      <mat-chip-row
-        *ngFor="let tagItem of tag"
-        [removable]="removable"
-        (removed)="remove(tagItem)"
-        class="tag"
-      >
-        {{ tagItem.name }}
-        <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
-      </mat-chip-row>
+    <mat-chip-row
+  *ngFor="let tagItem of tag; let i = index"
+  (removed)="remove(tagItem)">
+
+  <input
+    [(ngModel)]="tagItem.name"
+    (blur)="tagsUpdate.emit(tagsToStrings(this.tag))"
+    style="border:none; background:transparent; width:80px"
+  />
+
+  <button matChipRemove>
+    <mat-icon>cancel</mat-icon>
+  </button>
+
+</mat-chip-row>
       <input
         matInput
         placeholder="Add tags"

--- a/web/src/app/logbook/core/tag-editor/tag-editor.component.html
+++ b/web/src/app/logbook/core/tag-editor/tag-editor.component.html
@@ -14,21 +14,19 @@
   </button>
   <mat-form-field [floatLabel]="'auto'" subscriptSizing="dynamic">
     <mat-chip-grid #chipList aria-label="Tag selection">
-    <mat-chip-row
-  *ngFor="let tagItem of tag; let i = index"
-  (removed)="remove(tagItem)">
-
-  <input
-    [(ngModel)]="tagItem.name"
-    (blur)="tagsUpdate.emit(tagsToStrings(this.tag))"
-    style="border:none; background:transparent; width:80px"
-  />
-
-  <button matChipRemove>
-    <mat-icon>cancel</mat-icon>
-  </button>
-
-</mat-chip-row>
+      <mat-chip-row
+        *ngFor="let tagItem of tag; let i = index"
+        (removed)="remove(tagItem)"
+      >
+        <input
+          [(ngModel)]="tagItem.name"
+          (blur)="tagsUpdate.emit(tagsToStrings(this.tag))"
+          style="border:none; background:transparent; width:80px"
+        />
+        <button matChipRemove>
+          <mat-icon>cancel</mat-icon>
+        </button>
+      </mat-chip-row>
       <input
         matInput
         placeholder="Add tags"


### PR DESCRIPTION
## Feature Description

Previously, tags associated with a snippet could only be removed and re-added,
but not directly edited. This made updating tags inefficient and unintuitive.

This update introduces inline editing for tags in the Modify Data Snippet dialog.
Users can now directly click and edit tag text without deleting existing tags.

## Implementation

- Updated tag-editor.component.html to replace static tag display
  with editable input fields
- Enabled two-way binding using [(ngModel)]="tag.name"

## Result

- Users can edit tags directly
- Improved usability and workflow efficiency
- No need to delete and recreate tags

## Related Issue

Closes #454