### PR TITLE
Revert "chore(api): move rs.initiate to post_start (#576)"

### DIFF
--- a/sci-log-db/compose.yaml
+++ b/sci-log-db/compose.yaml
@@ -5,10 +5,8 @@ services:
     command: ["--replSet", "rs0"]
     volumes:
       - mongo_data:/data/db
-    post_start:
-      - command: ["mongosh", "--eval", "try { rs.status() } catch (e) { rs.initiate({_id:'rs0', members:[{_id:0, host:'mongo:27017'}]}) }"]
     healthcheck:
-      test: ["CMD", "mongosh", "--eval", "rs.status()"]
+      test: ["CMD", "mongosh", "--eval", "try { rs.status() } catch(e) { rs.initiate({_id:'rs0', members:[{_id:0, host:'mongo:27017'}]}) }"]
 
   mongo-seed:
     image: mongo:8


### PR DESCRIPTION
This reverts commit 1af16cc3a233909aedb655462ca32209944baec0.

`mongod` is not consistently running when the post_start script is
executed, which causes the `rs.status()` command to fail even if the
replica set is already initialized. When this happens, `rs.initiate()`
is called again and exists with an error code, resulting in the `api`
container not getting launched.
