### PR TITLE
fix(api): run tests inside the dev container

### DIFF
--- a/sci-log-db/Dockerfile
+++ b/sci-log-db/Dockerfile
@@ -24,8 +24,8 @@ RUN --mount=type=bind,source=package.json,target=package.json \
     --mount=type=cache,target=/root/.npm,sharing=locked \
     npm ci --no-audit --no-fund
 
-# Ahead-of-time TypeScript compilation. Its only job is to produce dist/
-# for the production stage to copy from — not meant to be run directly.
+# Ahead-of-time TypeScript compilation. Produces dist/ for the
+# test and production stages.
 FROM dev-deps AS build
 
 COPY --chown=node:node . .
@@ -48,12 +48,10 @@ CMD ["npm", "run", "dev"]
 # Runs the test suite once and exits. Kept separate from development so CI
 # (and local `docker compose up api-test`) can build --target test without
 # replicating the env vars, user, and command overrides in every caller.
-FROM dev-deps AS test
+FROM build AS test
 
 ENV NODE_ENV=test \
     CI=true
-
-COPY --chown=node:node . .
 
 USER node
 

--- a/sci-log-db/package.json
+++ b/sci-log-db/package.json
@@ -20,7 +20,6 @@
     "prettier:fix": "npm run prettier:cli -- --write",
     "eslint": "lb-eslint --report-unused-disable-directives .",
     "eslint:fix": "npm run eslint -- --fix",
-    "pretest": "npm run clean && npm run build && cp -r src/__tests__/test-data dist/__tests__/",
     "test": "lb-mocha --allow-console-logs --exit \"dist/__tests__\"",
     "posttest": "npm run lint",
     "migrate": "node ./dist/migrate",

--- a/sci-log-db/src/__tests__/acceptance/eln-import.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/eln-import.acceptance.ts
@@ -5,8 +5,8 @@ import {SciLogDbApplication} from '../..';
 import {clearDatabase, createUserToken, setupApplication} from './test-helper';
 
 const SCILOG_ELN_PATH = path.resolve(
-  __dirname,
-  '..',
+  'src',
+  '__tests__',
   'test-data',
   'scilog.eln',
 );

--- a/sci-log-db/src/__tests__/acceptance/functional-accounts.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/functional-accounts.acceptance.ts
@@ -13,12 +13,7 @@ import {Basesnippet, Location, Logbook, Paragraph} from '../../models';
 
 class TestFunctionalAccountsApp extends SciLogDbApplication {
   locations = ['location1', 'location2'];
-  idsLocation: Record<string, string>;
-
-  constructor() {
-    super(SciLogDbApplication);
-    this.idsLocation = {};
-  }
+  idsLocation: Record<string, string> = {};
 
   async createLocationSnippets(location: string) {
     const locationId = await this.createLogbook(location, {

--- a/sci-log-db/src/__tests__/acceptance/migrate.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/migrate.acceptance.ts
@@ -79,7 +79,7 @@ describe('Migrate', function (this: Suite) {
     const bucket: GridFSBucket = new mongodb.GridFSBucket(db);
     const uploadStream = bucket.openUploadStream('hello.txt');
     fs.createReadStream(
-      path.resolve(__dirname, '../test-data', 'hello.txt'),
+      path.resolve('src', '__tests__', 'test-data', 'hello.txt'),
     ).pipe(uploadStream);
     await new Promise((resolve, reject) => {
       uploadStream.on('error', (err: unknown) => {


### PR DESCRIPTION
The pretest script ran `npm run clean` which deleted dist/, crashing
the dev server's tsc --watch and node --watch processes. This broke
the Swagger UI and required a container restart.

The clean step was unnecessary: CI always runs tests in a fresh
container (no stale dist/), and the dev container keeps dist/ in sync
via tsc --watch with incremental compilation.

Remove pretest entirely by:
- Deriving the Dockerfile test stage from the build stage (which
already produces dist/) instead of rebuilding from dev-deps
- Referencing test fixtures from src/ directly instead of copying
them to dist/, following the standard Mocha convention

Also fix TestFunctionalAccountsApp: its constructor passed the class
itself as config instead of forwarding the options argument, silently
ignoring the port: 0 assignment and hardcoding port 3000. This was
masked by the old pretest killing the dev server. Removing the
unnecessary constructor lets the parent forward config correctly.

Close: #601
