### PR TITLE
feat(api): add url to sdPublisher Organization

### DIFF
--- a/sci-log-db/src/services/entity-builder.service.ts
+++ b/sci-log-db/src/services/entity-builder.service.ts
@@ -102,6 +102,7 @@ export class EntityBuilderService {
       '@id': 'https://github.com/paulscherrerinstitute/scilog',
       '@type': 'Organization',
       name: 'SciLog',
+      url: 'https://github.com/paulscherrerinstitute/scilog',
     };
   }
 


### PR DESCRIPTION
The ELN file format spec lists `url` as a SHOULD on the
sdPublisher Organization. Without it, .eln files produced by
SciLog can't round-trip through the importer we just added —
its metadata validator rejects an Organization missing `url`.

Close: #600
