### PR TITLE
fix(api): emit contentSize as string per ELN spec

### DIFF
--- a/sci-log-db/src/services/entity-builder.service.ts
+++ b/sci-log-db/src/services/entity-builder.service.ts
@@ -67,7 +67,7 @@ export class EntityBuilderService {
       '@type': string;
       name: string;
       encodingFormat: string;
-      contentSize?: number;
+      contentSize?: string;
       sha256?: string;
     } = {
       '@id': this.getFilePath(
@@ -80,7 +80,7 @@ export class EntityBuilderService {
       encodingFormat: fileObj.contentType,
     };
     if (fileObj.contentSize !== undefined) {
-      result['contentSize'] = fileObj.contentSize;
+      result['contentSize'] = String(fileObj.contentSize);
     }
     if (fileObj.contentSha256 !== undefined) {
       result['sha256'] = fileObj.contentSha256;


### PR DESCRIPTION
The .eln file format spec defines `contentSize` as a string
containing the number of bytes (no units). The export emitted
it as a JSON number, producing technically invalid .eln files.

Close: #608
