### PR TITLE
chore(api): enable init process in dev container

### DIFF
--- a/sci-log-db/compose.yaml
+++ b/sci-log-db/compose.yaml
@@ -33,6 +33,7 @@ services:
       - .:/home/node/app
       - node_modules:/home/node/app/node_modules
     tty: true
+    init: true
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3000/api/v1').then(r => { if (!r.ok) throw r.status })"]
     environment:


### PR DESCRIPTION
Set `init: true` on the api-development service so PID 1 reaps
zombies and forwards signals correctly, preventing orphaned
node/tsc processes when the container stops.
