### PR TITLE
fix(api): build once before starting dev watchers

### DIFF
--- a/sci-log-db/package.json
+++ b/sci-log-db/package.json
@@ -25,7 +25,7 @@
     "migrate": "node ./dist/migrate",
     "openapi-spec": "node ./dist/openapi-spec",
     "clean": "lb-clean dist *.tsbuildinfo .eslintcache",
-    "dev": "tsc --watch & node --watch --enable-source-maps ."
+    "dev": "tsc && (tsc --watch & node --watch --enable-source-maps .)"
   },
   "repository": {
     "type": "git"


### PR DESCRIPTION
`npm run dev` started `node --watch .` in parallel with the first
`tsc --watch` pass, so node could boot against missing or stale
`dist/` output. Run a one-shot `tsc` first, then launch the
watchers.
