### PR TITLE
refactor(api): extract FileStorageService

### DIFF
--- a/sci-log-db/src/controllers/file.controller.ts
+++ b/sci-log-db/src/controllers/file.controller.ts
@@ -1,6 +1,6 @@
 import {authenticate} from '@loopback/authentication';
 import {authorize} from '@loopback/authorization';
-import {inject} from '@loopback/core';
+import {inject, service} from '@loopback/core';
 import {
   Count,
   CountSchema,
@@ -25,15 +25,15 @@ import {
 } from '@loopback/rest';
 import {SecurityBindings, UserProfile} from '@loopback/security';
 import {formidable, File} from 'formidable';
-import fs from 'fs';
+import {createReadStream} from 'node:fs';
 import _ from 'lodash';
 import {Filesnippet} from '../models/file.model';
 import {FileRepository} from '../repositories/file.repository';
 import {basicAuthorization} from '../services/basic.authorizor';
+import {FileStorageService} from '../services/file-storage.service';
 import {validateFieldsVSModel} from '../utils/misc';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 
-import * as mongodb from 'mongodb';
 import crypto from 'crypto';
 
 const filesnippetModel = modelToJsonSchema(Filesnippet);
@@ -68,16 +68,12 @@ class MissingFileError extends Error {
   voters: [basicAuthorization],
 })
 export class FileController {
-  bucket: mongodb.GridFSBucket;
   constructor(
     @inject(SecurityBindings.USER) private user: UserProfile,
     @repository(FileRepository)
     public fileRepository: FileRepository,
-  ) {
-    this.bucket = new mongodb.GridFSBucket(
-      this.fileRepository.dataSource.connector?.db,
-    );
-  }
+    @service(FileStorageService) private fileStorage: FileStorageService,
+  ) {}
 
   @post('/filesnippet', {
     security: OPERATION_SECURITY_SPEC,
@@ -132,7 +128,10 @@ export class FileController {
     request: Request,
   ): Promise<Filesnippet> {
     const formData = await this.parseFormData(request);
-    formData.fields._fileId = await this.uploadToGridfs(formData.file.filepath);
+    formData.fields._fileId = await this.fileStorage.upload(
+      createReadStream(formData.file.filepath),
+      formData.file.originalFilename ?? formData.file.filepath,
+    );
     formData.fields.accessHash = crypto.randomBytes(64).toString('hex');
     const file = await this.fileRepository.create(
       _.omit(formData.fields, ['id']),
@@ -296,7 +295,7 @@ export class FileController {
       throw new HttpErrors.BadRequest(`Retrieving sandbox data is deprecated.`);
     }
     response.set('Content-Type', data.contentType);
-    this.bucket.openDownloadStream(data._fileId).pipe(response);
+    this.fileStorage.downloadStream(data._fileId).pipe(response);
     return response;
   }
 
@@ -329,7 +328,10 @@ export class FileController {
     request: Request,
   ): Promise<void> {
     const formData = await this.parseFormData(request);
-    formData.fields._fileId = await this.uploadToGridfs(formData.file.filepath);
+    formData.fields._fileId = await this.fileStorage.upload(
+      createReadStream(formData.file.filepath),
+      formData.file.originalFilename ?? formData.file.filepath,
+    );
     await this.fileRepository.updateById(id, _.omit(formData.fields, ['id']), {
       currentUser: this.user,
     });
@@ -415,22 +417,5 @@ export class FileController {
     const file = files.file[0];
     const fileSnippet = this.addFormDataToFileSnippet(parsedFields, file);
     return {fields: fileSnippet, file};
-  }
-
-  async uploadToGridfs(filepath: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const readStream = fs.createReadStream(filepath);
-      const uploadStream = this.bucket.openUploadStream(filepath);
-      readStream.pipe(uploadStream);
-      const id = uploadStream.id;
-      uploadStream
-        .on('error', (error: unknown) => {
-          console.error(error);
-          reject({error});
-        })
-        .on('finish', () => {
-          resolve(id.toString());
-        });
-    });
   }
 }

--- a/sci-log-db/src/services/file-storage.service.ts
+++ b/sci-log-db/src/services/file-storage.service.ts
@@ -1,0 +1,35 @@
+import {BindingScope, injectable} from '@loopback/core';
+import {repository} from '@loopback/repository';
+import {GridFSBucket, GridFSBucketReadStream, ObjectId} from 'mongodb';
+import {Readable} from 'node:stream';
+import {pipeline} from 'node:stream/promises';
+import {FileRepository} from '../repositories/file.repository';
+
+/**
+ * Bridge to GridFS for file byte storage.
+ *
+ * Owns the GridFSBucket so callers (controllers, import services) don't have
+ * to know about the underlying mongo connection. Exposes only the operations
+ * SciLog actually performs against the bucket.
+ */
+@injectable({scope: BindingScope.SINGLETON})
+export class FileStorageService {
+  private readonly bucket: GridFSBucket;
+
+  constructor(@repository(FileRepository) fileRepository: FileRepository) {
+    this.bucket = new GridFSBucket(fileRepository.dataSource.connector?.db);
+  }
+
+  /** Pipe bytes into GridFS. Returns the new GridFS file id. */
+  async upload(source: Readable, filename: string): Promise<string> {
+    const uploadStream = this.bucket.openUploadStream(filename);
+    await pipeline(source, uploadStream);
+    return uploadStream.id.toString();
+  }
+
+  /** Open a read stream for a GridFS file id (caller pipes it where needed). */
+  downloadStream(fileId: string | ObjectId): GridFSBucketReadStream {
+    const id = typeof fileId === 'string' ? new ObjectId(fileId) : fileId;
+    return this.bucket.openDownloadStream(id);
+  }
+}

--- a/sci-log-db/src/services/index.ts
+++ b/sci-log-db/src/services/index.ts
@@ -6,3 +6,4 @@
 export * from './ro-crate-export.service';
 export * from './entity-builder.service';
 export * from './archive.service';
+export * from './file-storage.service';


### PR DESCRIPTION
The upcoming ELN import flow needs to upload files to GridFS from
in-memory buffers (the bytes are extracted from a zipped .eln). The
existing FileController.uploadToGridfs only accepted a filesystem path,
and a service calling a controller is the wrong dependency direction
anyway — GridFS is infrastructure, not an interface adapter.

FileStorageService now owns the GridFSBucket and exposes the two
operations SciLog actually performs: upload(stream, filename) and
downloadStream(fileId). Both FileController and (soon) ElnImportService
depend on this shared service rather than each instantiating their own
bucket.

While here:
- replaces the hand-rolled Promise wrapper around openUploadStream with
node:stream/promises.pipeline, which propagates errors and cleans up
streams correctly without manual event listeners.
- stores the uploaded file's originalFilename in GridFS instead of the
formidable temp path.
- adds explicit string→ObjectId conversion in downloadStream so the
types match the mongodb signature.

See: #604
