### PR TITLE
feat(api): surface logbook author on ELN export root

### DIFF
--- a/sci-log-db/src/__tests__/unit/service.ro-crate-export.unit.ts
+++ b/sci-log-db/src/__tests__/unit/service.ro-crate-export.unit.ts
@@ -73,6 +73,9 @@ describe('RoCrateExportService (unit)', () => {
     expect(rocrate.root.hasPart).to.containEql({
       '@id': entityBuilder.getEntityId('logbook-1'),
     });
+    expect(rocrate.root.author).to.containEql({
+      '@id': 'person://user-1@test.com',
+    });
     const logbookEntity = rocrate.getEntity(
       entityBuilder.getEntityId('logbook-1'),
     );

--- a/sci-log-db/src/services/ro-crate-export.service.ts
+++ b/sci-log-db/src/services/ro-crate-export.service.ts
@@ -66,6 +66,7 @@ export class RoCrateExportService {
 
     const author = this.entityBuilder.buildPerson(logbook.createdBy);
     this.crate.addEntity(author);
+    this.crate.root.author = author;
     this.crate.root.hasPart.push(
       this.entityBuilder.buildLogbookEntity(logbook, author),
     );


### PR DESCRIPTION
The root entity in ELN exports already carries the logbook's name,
description, and dataset metadata, but omitted the author — even
though every other entity (logbook, message, comment) records it.
Mirror the logbook entity's author on the root so consumers can
identify the owner from the top-level metadata, keeping the export
internally consistent and easier for downstream tools (including a
future import path) to consume uniformly.

Close: #617
