### PR TITLE
fix(api): route subsnippet relations via unscoped repo

### DIFF
--- a/sci-log-db/src/repositories/autoadd.repository.base.ts
+++ b/sci-log-db/src/repositories/autoadd.repository.base.ts
@@ -28,10 +28,9 @@ export class AutoAddRepository<
   ID,
   Relations extends object = {},
 > extends DefaultCrudRepository<T, ID, Relations> {
-  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-  public readonly parent: BelongsToAccessor<Entity, any>;
+  public readonly parent: BelongsToAccessor<Basesnippet, ID>;
 
-  public readonly subsnippets: HasManyRepositoryFactory<T, string>;
+  public readonly subsnippets: HasManyRepositoryFactory<Basesnippet, string>;
 
   readonly acls = [
     'createACL',
@@ -62,14 +61,24 @@ export class AutoAddRepository<
     dataSource: juggler.DataSource,
   ) {
     super(entityClass, dataSource);
+    // Route subsnippets/parent through the unscoped BasesnippetRepository;
+    // otherwise the subclass's snippetType scope is re-applied to the
+    // relation query and silently drops children of a different kind.
+    // The cast bridges SnippetRepositoryMixin's type erasure.
+    const basesnippetRepoGetter: Getter<
+      DefaultCrudRepository<Basesnippet, string>
+    > = () =>
+      this.baseSnippetRepository() as unknown as Promise<
+        DefaultCrudRepository<Basesnippet, string>
+      >;
     this.subsnippets = this.createHasManyRepositoryFactoryFor(
       'subsnippets',
-      Getter.fromValue(this),
+      basesnippetRepoGetter,
     );
 
     this.parent = this.createBelongsToAccessorFor(
       'parent',
-      Getter.fromValue(this),
+      basesnippetRepoGetter,
     );
 
     // add these lines to register inclusion resolver.


### PR DESCRIPTION
The hasMany/belongsTo factories on AutoAddRepository were wired with
Getter.fromValue(this), so on scoped sibling repositories the target
resolved back to the calling repo. Its model-level snippetType scope
was then re-applied to the relation query and silently dropped every
child of a different kind: GET /logbooks/{id}?include=subsnippets,
GET /paragraphs/{id}?include=parent, and any equivalent on Location
all returned empty relations without error.

Route the factories through the existing baseSnippetRepository()
helper instead; it returns the unscoped BasesnippetRepository in
every case and matches the path other call sites in this file
already take. The cast bridges SnippetRepositoryMixin's type erasure.

Tighten parent/subsnippets field types to Basesnippet now that the
target is explicit.

Close: #629
