### PR TITLE
test(api): mirror OIDC email-in-roles in test helper

### DIFF
--- a/sci-log-db/src/__tests__/acceptance/file.controller.acceptance.ts
+++ b/sci-log-db/src/__tests__/acceptance/file.controller.acceptance.ts
@@ -379,7 +379,7 @@ describe('File controller services', function (this: Suite) {
       .set('Authorization', 'Bearer ' + token)
       .field('fields', '{"description": "something"}')
       .attach('file', __filename)
-      .expect(404)
+      .expect(204)
       .then(result => result)
       .catch(err => {
         throw err;

--- a/sci-log-db/src/__tests__/acceptance/test-helper.ts
+++ b/sci-log-db/src/__tests__/acceptance/test-helper.ts
@@ -72,7 +72,7 @@ export async function createAUser(
   const userRepo: UserRepository = await app.get('repositories.UserRepository');
   const newUser = await userRepo.create({
     ..._.omit(user, 'roles'),
-    roles: user.roles.concat(additionalRoles),
+    roles: user.roles.concat(additionalRoles, user.email),
   });
   newUser.id = newUser.id.toString();
 


### PR DESCRIPTION
The OIDC authentication strategy appends the user's email to their
roles (authentication-strategies/types.ts:90-94), but the acceptance
test helper did not — so test users had a different role shape from
real users. This divergence let bugs hide in any code path that
relies on `currentUser.roles` containing the email (e.g. the access
observer's `readACL inq roles` filter on a snippet whose readACL was
defaulted to `createdBy`).

Append `user.email` to the constructed roles in `createAUser` so
acceptance tests run against the same role shape as production.

The file controller test "patches a file after having created it"
previously expected 404 — confirmed with Carlo (commit 900ebe7) that
the 404 was a mistake; the happy-path create-then-patch should
return 204. Fixed.
