### PR TITLE
feat(api): make oidc role claims configurable

### DIFF
--- a/config/be/oidc.example.json
+++ b/config/be/oidc.example.json
@@ -11,7 +11,8 @@
     "clientID": "YOURCLIENT",
     "clientSecret": "YOURSECRET",
     "callbackURL": "http://localhost:3000/auth/keycloak/callback",
-    "scope": ["email", "profile", "openid"],
+    "scope": ["email", "profile", "openid", "groups"],
+    "rolesClaims": ["roles", "groups"],
     "successRedirect": "http://localhost:4200/login",
     "skipUserProfile": false
 }

--- a/sci-log-db/oidc.example.json
+++ b/sci-log-db/oidc.example.json
@@ -11,7 +11,8 @@
     "clientID": "scilog",
     "clientSecret": "YOUR-CLIENT-SECRET",
     "callbackURL": "http://localhost:3000/auth/keycloak/callback/",
-    "scope": ["email", "profile", "openid"],
+    "scope": ["email", "profile", "openid", "groups"],
+    "rolesClaims": ["roles", "groups"],
     "successRedirect": "http://localhost:4200/login",
     "skipUserProfile": false
 }

--- a/sci-log-db/src/__tests__/unit/authentication-strategies.oidc.unit.ts
+++ b/sci-log-db/src/__tests__/unit/authentication-strategies.oidc.unit.ts
@@ -5,6 +5,7 @@ import {roles} from '../../authentication-strategies/roles';
 import {
   extractFirstLastName,
   findOrCreateUser,
+  verifyFunctionFactory,
 } from '../../authentication-strategies/types';
 import {UserRepository} from '../../repositories';
 import _ from 'lodash';
@@ -34,6 +35,35 @@ describe('Authentication strategies roles', function (this: Suite) {
       _json: {roles: ['g12345', 'g78910']},
     });
     expect(emptyRoles).to.be.eql(['g12345', 'g78910']);
+  });
+
+  it('Should merge roles from the default groups claim', () => {
+    const profile = {} as Profile;
+    const mergedRoles = roles({
+      ...profile,
+      _json: {roles: ['g12345'], groups: ['groupA', 'groupB']},
+    });
+    expect(mergedRoles).to.be.eql(['g12345', 'groupA', 'groupB']);
+  });
+
+  it('Should read roles from a custom-named claim when configured', () => {
+    const profile = {} as Profile;
+    const customRoles = roles(
+      {
+        ...profile,
+        _json: {roles: ['ignored'], beamtimes: ['p11111', 'p22222']},
+      },
+      ['beamtimes'],
+    );
+    expect(customRoles).to.be.eql(['p11111', 'p22222']);
+  });
+
+  it('Should return an empty list when configured claim is absent', () => {
+    const profile = {} as Profile;
+    const customRoles = roles({...profile, _json: {roles: ['g12345']}}, [
+      'beamtimes',
+    ]);
+    expect(customRoles).to.be.eql([]);
   });
 
   it('Should return the list of roles without applying any regex', () => {
@@ -134,6 +164,43 @@ describe('Authentication strategies roles', function (this: Suite) {
       .true;
     // eslint-disable-next-line no-unused-expressions
     expect(updateById.notCalled).to.be.true;
+  });
+
+  it('Should build user roles from the configured claim via verifyFunctionFactory', done => {
+    const stubUserRepo = createStubInstance(UserRepository);
+    (stubUserRepo.findOne as sinon.SinonStub).resolves(null);
+    const createStub = (stubUserRepo.create as sinon.SinonStub).resolves();
+    const verify = verifyFunctionFactory(stubUserRepo, ['beamtimes']);
+    const profile = {
+      emails: [{value: 'a@user'}],
+      displayName: 'A User',
+      _json: {roles: ['ignored'], beamtimes: ['p11111']},
+    } as unknown as Profile;
+    verify(
+      'iss',
+      profile,
+      {} as never,
+      undefined,
+      'idToken',
+      'accessToken',
+      'refreshToken',
+      undefined,
+      (err: unknown) => {
+        try {
+          // eslint-disable-next-line no-unused-expressions
+          expect(err).to.be.null;
+          const created = createStub.firstCall.args[0];
+          expect(created.roles).to.be.eql([
+            'p11111',
+            'any-authenticated-user',
+            'a@user',
+          ]);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      },
+    );
   });
 
   it('Should update a user', async () => {

--- a/sci-log-db/src/__tests__/unit/authentication-strategies.oidc.unit.ts
+++ b/sci-log-db/src/__tests__/unit/authentication-strategies.oidc.unit.ts
@@ -37,12 +37,15 @@ describe('Authentication strategies roles', function (this: Suite) {
     expect(emptyRoles).to.be.eql(['g12345', 'g78910']);
   });
 
-  it('Should merge roles from the default groups claim', () => {
+  it('Should merge roles from groups claim when explicitly configured', () => {
     const profile = {} as Profile;
-    const mergedRoles = roles({
-      ...profile,
-      _json: {roles: ['g12345'], groups: ['groupA', 'groupB']},
-    });
+    const mergedRoles = roles(
+      {
+        ...profile,
+        _json: {roles: ['g12345'], groups: ['groupA', 'groupB']},
+      },
+      ['roles', 'groups'],
+    );
     expect(mergedRoles).to.be.eql(['g12345', 'groupA', 'groupB']);
   });
 

--- a/sci-log-db/src/authentication-strategies/oidc.ts
+++ b/sci-log-db/src/authentication-strategies/oidc.ts
@@ -29,7 +29,7 @@ export class OIDCAuthentication implements AuthenticationStrategy {
   ) {
     const strategy: Strategy = new oidcStrategy(
       this.oidcOptions,
-      verifyFunctionFactory(this.userRepository),
+      verifyFunctionFactory(this.userRepository, this.oidcOptions.rolesClaims),
     );
     this.strategy = new StrategyAdapter(
       strategy,

--- a/sci-log-db/src/authentication-strategies/roles.ts
+++ b/sci-log-db/src/authentication-strategies/roles.ts
@@ -1,9 +1,21 @@
 import {Profile} from 'passport';
 
-export function roles(profile: Profile & {_json?: {roles?: string[]}}) {
+// kept for backward compatibility
+
+export const DEFAULT_ROLES_CLAIMS = ['roles', 'groups'];
+
+export function roles(
+  profile: Profile & {_json?: Record<string, unknown>},
+  rolesClaims: string[] = DEFAULT_ROLES_CLAIMS,
+): string[] {
+  const json = profile._json ?? {};
+  const rolesFromProfile = rolesClaims.flatMap(claim => {
+    const value = json[claim];
+    return Array.isArray(value)
+      ? value.filter((v): v is string => typeof v === 'string')
+      : [];
+  });
   if (profile.username && /^e[0-9]{5}$/.test(profile.username ?? ''))
-    return (profile._json?.roles ?? []).concat([
-      'p' + profile.username?.substring(1),
-    ]);
-  else return profile._json?.roles ?? [];
+    return rolesFromProfile.concat(['p' + profile.username?.substring(1)]);
+  else return rolesFromProfile;
 }

--- a/sci-log-db/src/authentication-strategies/roles.ts
+++ b/sci-log-db/src/authentication-strategies/roles.ts
@@ -1,8 +1,6 @@
 import {Profile} from 'passport';
 
-// kept for backward compatibility
-
-export const DEFAULT_ROLES_CLAIMS = ['roles', 'groups'];
+export const DEFAULT_ROLES_CLAIMS = ['roles'];
 
 export function roles(
   profile: Profile & {_json?: Record<string, unknown>},

--- a/sci-log-db/src/authentication-strategies/types.ts
+++ b/sci-log-db/src/authentication-strategies/types.ts
@@ -35,6 +35,7 @@ export type OIDCOptions = {
   skipUserProfile: boolean;
   endSessionEndpoint: string;
   postLogoutRedirectUri: string;
+  rolesClaims?: string[];
 };
 
 export type VerifyFunction = (
@@ -62,6 +63,7 @@ export type VerifyFunction = (
 
 export const verifyFunctionFactory = function (
   userRepo: UserRepository,
+  rolesClaims?: string[],
 ): VerifyFunction {
   return function (
     claimIss: string,
@@ -88,7 +90,7 @@ export const verifyFunctionFactory = function (
       lastName: lastName,
       username: profile.username,
       roles: [
-        ...roles(profile),
+        ...roles(profile, rolesClaims),
         'any-authenticated-user',
         profile.emails[0].value,
       ],


### PR DESCRIPTION
Read OIDC role/group claims from a configurable rolesClaims option
instead of hard-coding the roles claim, so deployments using Keycloak
group memberships (e.g. DESY) can map them to SciLog roles via config.

Close: #606