### PR TITLE
feat: add unlink logbook functionality

### DIFF
--- a/web/src/app/core/scicat.service.ts
+++ b/web/src/app/core/scicat.service.ts
@@ -123,4 +123,30 @@ export class ScicatService {
       }),
     );
   }
+
+  unlinkLogbookFromDataset(logbookId: string, pid: string): Observable<boolean> {
+    return this.getDataset(pid).pipe(
+      switchMap((dataset) => {
+        type RelationshipSchema = RelationshipClass & { _id: string };
+        const existing = ((dataset.relationships ?? []) as RelationshipSchema[]).map(
+          ({ _id, ...rest }) => rest,
+        );
+        const filtered = existing.filter(
+          (rel) => !(rel.relationship === 'Logbook' && rel.externalId === logbookId),
+        );
+        if (filtered.length === existing.length) {
+          return of(false);
+        }
+        return this.datasetsService
+          .datasetsControllerFindByIdAndUpdateV3(
+            pid,
+            { relationships: filtered },
+            undefined,
+            undefined,
+            { context: new HttpContext().set(IF_UNMODIFIED_SINCE, dataset.updatedAt) },
+          )
+          .pipe(map(() => true));
+      }),
+    );
+  }
 }

--- a/web/src/app/core/scicat.service.ts
+++ b/web/src/app/core/scicat.service.ts
@@ -14,6 +14,7 @@ import { HttpContext, HttpContextToken } from '@angular/common/http';
 export type Dataset = OutputDatasetObsoleteDto;
 export type DatasetSummary = Pick<Dataset, 'pid' | 'datasetName' | 'creationTime'>;
 export type ScicatUser = ReturnedUserDto;
+type RelationshipSchema = RelationshipClass & { _id: string };
 
 export const IF_UNMODIFIED_SINCE = new HttpContextToken<string>(() => undefined);
 
@@ -93,7 +94,6 @@ export class ScicatService {
         if (alreadyLinked) {
           return of(false);
         }
-        type RelationshipSchema = RelationshipClass & { _id: string };
         // the actual relationship object also contains an _id, it must be removed from the update request
         const existingRelationships = ((dataset.relationships ?? []) as RelationshipSchema[]).map(
           ({ _id, ...rest }) => rest,
@@ -127,7 +127,6 @@ export class ScicatService {
   unlinkLogbookFromDataset(logbookId: string, pid: string): Observable<boolean> {
     return this.getDataset(pid).pipe(
       switchMap((dataset) => {
-        type RelationshipSchema = RelationshipClass & { _id: string };
         const existing = ((dataset.relationships ?? []) as RelationshipSchema[]).map(
           ({ _id, ...rest }) => rest,
         );

--- a/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.html
+++ b/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.html
@@ -65,14 +65,15 @@
       <a mat-button [href]="scicatDatasetUrl" target="_blank"
         >Open in SciCat <mat-icon>open_in_new</mat-icon></a
       >
-      <button
-        mat-button
-        matTooltip="Link logbook to dataset"
-        (click)="linkLogbook()"
-        [disabled]="isUserLinkedDataset(selectedDataset.pid)"
-      >
-        <mat-icon>add_link</mat-icon> Link
-      </button>
+      @if (isUserLinkedDataset(selectedDataset.pid)) {
+        <button mat-button matTooltip="Unlink logbook from dataset" (click)="unlinkLogbook()">
+          <mat-icon>link_off</mat-icon> Unlink
+        </button>
+      } @else {
+        <button mat-button matTooltip="Link logbook to dataset" (click)="linkLogbook()">
+          <mat-icon>add_link</mat-icon> Link
+        </button>
+      }
     </mat-card-actions>
   </mat-card>
 </div>

--- a/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.spec.ts
+++ b/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.spec.ts
@@ -20,6 +20,7 @@ describe('ScicatViewerComponent', () => {
       'getDatasetDetailPageUrl',
       'getProposalPageUrl',
       'getUserLinkedDatasetsSummary',
+      'unlinkLogbookFromDataset',
     ]);
 
     scicatServiceSpy.getMyself.and.returnValue(of(null));
@@ -167,6 +168,30 @@ describe('ScicatViewerComponent', () => {
 
         expect(component.filteredDatasetSummary().map((ds) => ds.pid)).toEqual(expectedPids);
       });
+    });
+  });
+  describe('unlinkLogbook', () => {
+    it('removes pid from userLinkedPids on success', () => {
+      scicatServiceSpy.getDatasetsSummary.and.returnValue(
+        of([{ pid: '5', datasetName: 'Dataset 5', creationTime: '2024-01-05' }]),
+      );
+      scicatServiceSpy.getUserLinkedDatasetsSummary.and.returnValue(
+        of([{ pid: '5', datasetName: 'Dataset 5', creationTime: '2024-01-05' }]),
+      );
+      scicatServiceSpy.getDataset.and.returnValue(
+        of({ pid: '5', datasetName: 'Dataset 5', creationTime: '2024-01-05' } as Dataset),
+      );
+      scicatServiceSpy.unlinkLogbookFromDataset.and.returnValue(of(true));
+      logbookInfoServiceSpy.logbookInfo = { ownerGroup: 'group1', id: 'lb1' } as any;
+
+      component.ngOnInit();
+      expect(component.isUserLinkedDataset('5')).toBeTrue();
+
+      component.selectedDataset = { pid: '5' } as Dataset;
+      component.unlinkLogbook();
+
+      expect(scicatServiceSpy.unlinkLogbookFromDataset).toHaveBeenCalledWith('lb1', '5');
+      expect(component.isUserLinkedDataset('5')).toBeFalse();
     });
   });
 });

--- a/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.ts
+++ b/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.ts
@@ -180,4 +180,27 @@ export class ScicatViewerComponent implements OnInit {
       },
     });
   }
+
+  unlinkLogbook(): void {
+    if (!this.selectedDataset) return;
+    const logbookId = this.logbookInfoService.logbookInfo.id;
+    const pid = this.selectedDataset.pid;
+    this.scicatService.unlinkLogbookFromDataset(logbookId, pid).subscribe({
+      next: () => {
+        this.userLinkedPids.update((set) => {
+          const next = new Set(set);
+          next.delete(pid);
+          return next;
+        });
+        this.snackbarService.showSnackbarMessage(
+          'Logbook unlinked from dataset successfully',
+          'resolved',
+        );
+      },
+      error: (err) => {
+        console.log('Error unlinking logbook from dataset', err);
+        this.snackbarService.showSnackbarMessage('Error unlinking logbook from dataset', 'warning');
+      },
+    });
+  }
 }


### PR DESCRIPTION
Link feature was added in https://github.com/paulscherrerinstitute/scilog/pull/590. This PR adds the Unlink feature.

If the logbook is linked, an "Unlink" button is shown instead of the link button.
Unlinking removes the logbook from the dataset's relationship.

Claude Code was used to generate most of the code, as it closely mirrors the Link feature.

<img width="730" height="501" alt="localhost_4200_logbooks_693ffede61c7f5b987ece9d4_dashboard" src="https://github.com/user-attachments/assets/ddcb5fff-a331-41c7-8b89-ed4fe5924b63" />

