### PR TITLE
test(api): drop logbook file from ELN fixture

### DIFF
--- a/sci-log-db/src/__tests__/eln.helpers.ts
+++ b/sci-log-db/src/__tests__/eln.helpers.ts
@@ -47,11 +47,7 @@ export function validElnCrate(): ROCrate {
           description: 'a book',
           dateCreated: '2026-01-19T00:00:00.000Z',
           author: {'@id': '#author'},
-          hasPart: [
-            {'@id': './book/file.txt'},
-            {'@id': './book/message/'},
-            {'@id': './book/comment/'},
-          ],
+          hasPart: [{'@id': './book/message/'}, {'@id': './book/comment/'}],
         },
         {
           '@id': './book/file.txt',

--- a/sci-log-db/src/__tests__/unit/eln-translator.unit.ts
+++ b/sci-log-db/src/__tests__/unit/eln-translator.unit.ts
@@ -17,7 +17,7 @@ describe('ElnTranslator.toSciLog', () => {
             'eln:created:2026-01-19',
           ],
         },
-        hasPart: ['./book/file.txt', './book/message/', './book/comment/'],
+        hasPart: ['./book/message/', './book/comment/'],
         comment: [],
       });
     });


### PR DESCRIPTION
A logbook has no files of its own in the SciLog model — files attach
to paragraphs. The fixture listed a File directly in the Book's
hasPart, which no exporter produces. Remove it (the file stays
referenced by its message) so the fixture matches reality.
