### PR TITLE
fix(api): validate ELN comment references

### DIFF
--- a/sci-log-db/src/__tests__/unit/eln-archive.unit.ts
+++ b/sci-log-db/src/__tests__/unit/eln-archive.unit.ts
@@ -167,6 +167,14 @@ describe('ElnArchive.validateMetadata', () => {
     ]);
   });
 
+  it('rejects when comment references a non-existent entity', () => {
+    const crate = validElnCrate();
+    crate.addValues('./book/message/', 'comment', {'@id': './does-not-exist/'});
+    expect(ElnArchive.validateMetadata(crate)).to.containDeep([
+      {code: ElnErrorCode.INVALID_COMMENT},
+    ]);
+  });
+
   it('accepts numeric contentSize', () => {
     const crate = validElnCrate();
     crate.setProperty('./book/file.txt', 'contentSize', 123);

--- a/sci-log-db/src/services/eln-archive.ts
+++ b/sci-log-db/src/services/eln-archive.ts
@@ -20,6 +20,7 @@ export const ElnErrorCode = {
   MISSING_DATASET_FIELD: 'MISSING_DATASET_FIELD',
   INVALID_AUTHOR: 'INVALID_AUTHOR',
   INVALID_HAS_PART: 'INVALID_HAS_PART',
+  INVALID_COMMENT: 'INVALID_COMMENT',
   INVALID_CONTENT_SIZE: 'INVALID_CONTENT_SIZE',
   INVALID_ELN_ARCHIVE: 'INVALID_ELN_ARCHIVE',
   INVALID_ELN_STRUCTURE: 'INVALID_ELN_STRUCTURE',
@@ -195,6 +196,7 @@ export class ElnArchive {
       ...validateAuthors(crate),
       ...validateFiles(crate),
       ...validateHasPartReferences(crate),
+      ...validateCommentReferences(crate),
     ];
   }
 
@@ -472,6 +474,25 @@ function validateHasPartReferences(crate: ROCrate): ElnError[] {
         errors.push({
           code: ElnErrorCode.INVALID_HAS_PART,
           message: `Entity ${entity['@id']}: hasPart ${id} not found`,
+        });
+      }
+    }
+  }
+  return errors;
+}
+
+function validateCommentReferences(crate: ROCrate): ElnError[] {
+  const errors: ElnError[] = [];
+  for (const entity of crate.entities()) {
+    const comment = entity.comment;
+    if (!comment?.length) continue;
+
+    for (const ref of comment) {
+      const id = ref['@id'];
+      if (!crate.getEntity(id)) {
+        errors.push({
+          code: ElnErrorCode.INVALID_COMMENT,
+          message: `Entity ${entity['@id']}: comment ${id} not found`,
         });
       }
     }


### PR DESCRIPTION
A dataset's `comment` references were unchecked — only `hasPart` was
validated — so a dangling comment @id would pass metadata validation
and surface later as a malformed import. Validate them the same way and
report INVALID_COMMENT, rejecting the archive up front with the other
integrity errors.
