### PR TITLE
refactor(api): translate ELN into a SciLog tree

### DIFF
--- a/sci-log-db/src/__tests__/eln.helpers.ts
+++ b/sci-log-db/src/__tests__/eln.helpers.ts
@@ -82,7 +82,7 @@ export function validElnCrate(): ROCrate {
         },
       ],
     },
-    {array: true},
+    {array: true, link: true},
   );
 }
 

--- a/sci-log-db/src/__tests__/unit/eln-translator.unit.ts
+++ b/sci-log-db/src/__tests__/unit/eln-translator.unit.ts
@@ -4,21 +4,34 @@ import {ElnTranslator} from '../../services/eln-translator';
 import {validElnCrate} from '../eln.helpers';
 
 describe('ElnTranslator.toSciLog', () => {
+  it('assembles the tree: one paragraph with its file and nested comment', () => {
+    const draft = ElnTranslator.toSciLog(validElnCrate());
+    expect(draft.paragraphs).to.have.length(1);
+
+    const [message] = draft.paragraphs;
+    expect(message.fields.linkType).to.equal(LinkType.PARAGRAPH);
+    expect(message.files.map(file => file.elnId)).to.deepEqual([
+      './book/file.txt',
+    ]);
+
+    expect(message.paragraphs).to.have.length(1);
+    const [comment] = message.paragraphs;
+    expect(comment.fields.linkType).to.equal(LinkType.COMMENT);
+    expect(comment.files).to.be.empty();
+    expect(comment.paragraphs).to.be.empty();
+  });
+
   describe('logbook', () => {
-    it('extracts fields, hasPart, and provenance tags from the Book entity', () => {
-      expect(ElnTranslator.toSciLog(validElnCrate()).logbook).to.deepEqual({
-        fields: {
-          name: 'book',
-          description: 'a book',
-          tags: [
-            'eln:source:scilog',
-            'eln:id:./book/',
-            'eln:author:a@example.org',
-            'eln:created:2026-01-19',
-          ],
-        },
-        hasPart: ['./book/message/', './book/comment/'],
-        comment: [],
+    it('extracts fields and provenance tags from the Book entity', () => {
+      expect(ElnTranslator.toSciLog(validElnCrate()).fields).to.deepEqual({
+        name: 'book',
+        description: 'a book',
+        tags: [
+          'eln:source:scilog',
+          'eln:id:./book/',
+          'eln:author:a@example.org',
+          'eln:created:2026-01-19',
+        ],
       });
     });
 
@@ -27,7 +40,7 @@ describe('ElnTranslator.toSciLog', () => {
       crate.deleteProperty('./book/', 'description');
       crate.deleteProperty('./book/', 'dateCreated');
       crate.deleteProperty('./book/', 'author');
-      expect(ElnTranslator.toSciLog(crate).logbook.fields).to.deepEqual({
+      expect(ElnTranslator.toSciLog(crate).fields).to.deepEqual({
         name: 'book',
         description: undefined,
         tags: ['eln:source:scilog', 'eln:id:./book/'],
@@ -35,78 +48,90 @@ describe('ElnTranslator.toSciLog', () => {
     });
   });
 
-  describe('files', () => {
-    it('maps File entity fields, keyed by @id', () => {
-      expect(
-        ElnTranslator.toSciLog(validElnCrate()).files.get('./book/file.txt'),
-      ).to.deepEqual({
-        fields: {
-          name: 'file.txt',
-          filename: 'file.txt',
-          contentType: 'text/plain',
-          contentSize: 123,
-          contentSha256: '0'.repeat(64),
-          fileExtension: 'txt',
-          tags: ['eln:id:./book/file.txt'],
-        },
-        hasPart: [],
-        comment: [],
+  describe('paragraphs', () => {
+    it('maps Message entity fields, with linkType=paragraph and split keyword tags', () => {
+      const [message] = ElnTranslator.toSciLog(validElnCrate()).paragraphs;
+      expect(message.fields).to.deepEqual({
+        linkType: LinkType.PARAGRAPH,
+        textcontent: '<p>hello</p>',
+        tags: [
+          'eln:id:./book/message/',
+          'eln:author:a@example.org',
+          'eln:created:2026-01-19',
+          'atag',
+          'btag',
+        ],
+        defaultOrder: new Date('2026-01-19T00:00:00.000Z').getTime() * 1000,
       });
+    });
+  });
+
+  describe('files', () => {
+    it('embeds File entity fields on the paragraph that references them', () => {
+      const [message] = ElnTranslator.toSciLog(validElnCrate()).paragraphs;
+      expect(message.files).to.deepEqual([
+        {
+          elnId: './book/file.txt',
+          fields: {
+            name: 'file.txt',
+            filename: 'file.txt',
+            contentType: 'text/plain',
+            contentSize: 123,
+            contentSha256: '0'.repeat(64),
+            fileExtension: 'txt',
+            tags: ['eln:id:./book/file.txt'],
+          },
+        },
+      ]);
     });
 
     it('leaves fileExtension undefined when the name has no extension', () => {
       const crate = validElnCrate();
       crate.setProperty('./book/file.txt', 'name', 'README');
-      expect(
-        ElnTranslator.toSciLog(crate).files.get('./book/file.txt')?.fields
-          .fileExtension,
-      ).to.be.undefined();
+      const [message] = ElnTranslator.toSciLog(crate).paragraphs;
+      expect(message.files[0].fields.fileExtension).to.be.undefined();
     });
-  });
 
-  describe('paragraphs', () => {
-    it('maps Message entity fields, with linkType=paragraph and split keyword tags', () => {
-      expect(
-        ElnTranslator.toSciLog(validElnCrate()).paragraphs.get(
-          './book/message/',
-        ),
-      ).to.deepEqual({
-        fields: {
-          linkType: LinkType.PARAGRAPH,
-          textcontent: '<p>hello</p>',
-          tags: [
-            'eln:id:./book/message/',
-            'eln:author:a@example.org',
-            'eln:created:2026-01-19',
-            'atag',
-            'btag',
-          ],
-          defaultOrder: new Date('2026-01-19T00:00:00.000Z').getTime() * 1000,
-        },
-        hasPart: ['./book/file.txt'],
-        comment: ['./book/comment/'],
+    it('embeds files on a comment, not only on a paragraph', () => {
+      const crate = validElnCrate();
+      crate.addEntity({
+        '@id': './book/comment/img.png',
+        '@type': 'File',
+        name: 'img.png',
+        encodingFormat: 'image/png',
+        contentSize: '10',
+        sha256: '0'.repeat(64),
       });
+      crate.addValues('./book/comment/', 'hasPart', {
+        '@id': './book/comment/img.png',
+      });
+      const [message] = ElnTranslator.toSciLog(crate).paragraphs;
+      const [comment] = message.paragraphs;
+      expect(comment.files.map(file => file.elnId)).to.deepEqual([
+        './book/comment/img.png',
+      ]);
     });
   });
 
   describe('comments', () => {
+    it('nests a message comments as child paragraphs', () => {
+      const [message] = ElnTranslator.toSciLog(validElnCrate()).paragraphs;
+      expect(message.paragraphs).to.have.length(1);
+    });
+
     it('maps Comment entity fields, with linkType=comment', () => {
-      expect(
-        ElnTranslator.toSciLog(validElnCrate()).comments.get('./book/comment/'),
-      ).to.deepEqual({
-        fields: {
-          linkType: LinkType.COMMENT,
-          textcontent: '<p>a comment</p>',
-          tags: [
-            'eln:id:./book/comment/',
-            'eln:author:a@example.org',
-            'eln:created:2026-01-19',
-            'ctag',
-          ],
-          defaultOrder: new Date('2026-01-19T01:00:00.000Z').getTime() * 1000,
-        },
-        hasPart: [],
-        comment: [],
+      const [message] = ElnTranslator.toSciLog(validElnCrate()).paragraphs;
+      const [comment] = message.paragraphs;
+      expect(comment.fields).to.deepEqual({
+        linkType: LinkType.COMMENT,
+        textcontent: '<p>a comment</p>',
+        tags: [
+          'eln:id:./book/comment/',
+          'eln:author:a@example.org',
+          'eln:created:2026-01-19',
+          'ctag',
+        ],
+        defaultOrder: new Date('2026-01-19T01:00:00.000Z').getTime() * 1000,
       });
     });
   });

--- a/sci-log-db/src/services/eln-archive.ts
+++ b/sci-log-db/src/services/eln-archive.ts
@@ -167,7 +167,7 @@ export class ElnArchive {
     let crate: ROCrate;
     try {
       const raw = JSON.parse(entries.get(metadataPath)!.toString());
-      crate = new ROCrate(raw, {array: true});
+      crate = new ROCrate(raw, {array: true, link: true});
     } catch {
       return {
         ok: false,

--- a/sci-log-db/src/services/eln-translator.ts
+++ b/sci-log-db/src/services/eln-translator.ts
@@ -15,46 +15,16 @@ import {LinkType} from '../models/paragraph.model';
 
 export class ElnTranslator {
   /**
-   * Extract SciLog-shaped fields from ELN metadata. Returns drafts grouped
-   * by kind, each carrying the spec's relationship fields (`hasPart`,
-   * `comment`) as plain `@id` strings. The orchestrator drives creation in
-   * declaration order (logbook → files → paragraphs → comments), resolving
-   * references via the kind-specific Maps.
+   * Translate ELN metadata into a SciLog logbook draft: a tree whose nodes
+   * carry their embedded files and their nested paragraphs (a comment is a
+   * paragraph with `linkType=comment`). Files keep their `@id` so the
+   * orchestrator can fetch their bytes; the orchestrator assigns SciLog
+   * identity (id, hashes) when it creates them.
    */
-  static toSciLog(crate: ROCrate): ImportDraft {
-    let logbook: LogbookDraft | undefined;
-    const files = new Map<string, FileDraft>();
-    const paragraphs = new Map<string, ParagraphDraft>();
-    const comments = new Map<string, CommentDraft>();
-
-    for (const entity of crate.entities()) {
-      const types = entity['@type'] as string[];
-      const id = entity['@id'] as string;
-      const author = resolveAuthor(crate, entity);
-      const hasPart = extractRefs(entity.hasPart);
-      const comment = extractRefs(entity.comment);
-
-      if (types.includes('Book')) {
-        logbook = {fields: logbookFromBook(entity, author), hasPart, comment};
-      } else if (types.includes('Message')) {
-        paragraphs.set(id, {
-          fields: paragraphFromMessage(entity, author),
-          hasPart,
-          comment,
-        });
-      } else if (types.includes('Comment')) {
-        comments.set(id, {
-          fields: paragraphFromComment(entity, author),
-          hasPart,
-          comment,
-        });
-      } else if (types.includes('File')) {
-        files.set(id, {fields: filesnippetFromFile(entity), hasPart, comment});
-      }
-    }
-
-    if (!logbook) throw new Error('ElnTranslator: no Book entity in crate');
-    return {logbook, files, paragraphs, comments};
+  static toSciLog(crate: ROCrate): LogbookDraft {
+    const book = findBook(crate);
+    if (!book) throw new Error('ElnTranslator: no Book entity in crate');
+    return buildLogbook(book);
   }
 
   /**
@@ -102,60 +72,54 @@ export class ElnTranslator {
   }
 }
 
-function extractRefs(refs: unknown): string[] {
-  if (!Array.isArray(refs)) return [];
-  return refs.map(ref => (ref as Entity)['@id'] as string);
+// --- crate navigation (the crate is parsed in `link` mode, so reference
+// fields like `author`, `hasPart`, and `comment` yield linked entities) ---
+
+function findBook(crate: ROCrate): Entity | undefined {
+  return [...crate.entities()].find(entity => entity.$$hasType('Book'));
 }
 
-function resolveAuthor(crate: ROCrate, entity: Entity): Entity | undefined {
-  const authorId = entity.author?.[0]?.['@id'] as string | undefined;
-  return authorId ? crate.getEntity(authorId) : undefined;
+/** Linked entities of a given `@type` in `entity`'s `hasPart`. */
+function partsOfType(entity: Entity, type: string): Entity[] {
+  return (entity.hasPart ?? []).filter((part: Entity) => part.$$hasType(type));
 }
 
-function logbookFromBook(
-  book: Entity,
-  author: Entity | undefined,
-): Partial<Logbook> {
-  const dateCreated = book.dateCreated?.[0] as string | undefined;
-  const authorEmail = author?.email?.[0] as string | undefined;
+// --- field mappers: ELN entity → SciLog model fields ---
 
-  const tags = ['eln:source:scilog', `eln:id:${book['@id']}`];
+/** Provenance tags carried by every entity: ELN id, author, date created. */
+function provenanceTags(entity: Entity): string[] {
+  const tags = [`eln:id:${entity['@id']}`];
+  const authorEmail = entity.author?.[0]?.email?.[0] as string | undefined;
   if (authorEmail) tags.push(`eln:author:${authorEmail}`);
+  const dateCreated = entity.dateCreated?.[0] as string | undefined;
   if (dateCreated) tags.push(`eln:created:${dateCreated.slice(0, 10)}`);
+  return tags;
+}
 
+function logbookFromBook(book: Entity): Partial<Logbook> {
   return {
     name: book.name?.[0],
     description: book.description?.[0],
-    tags,
+    tags: ['eln:source:scilog', ...provenanceTags(book)],
   };
 }
 
-function paragraphFromMessage(
-  message: Entity,
-  author: Entity | undefined,
-): Partial<Paragraph> {
-  return paragraphFields(message, author, LinkType.PARAGRAPH);
+function paragraphFromMessage(message: Entity): Partial<Paragraph> {
+  return paragraphFromEntity(message, LinkType.PARAGRAPH);
 }
 
-function paragraphFromComment(
-  comment: Entity,
-  author: Entity | undefined,
-): Partial<Paragraph> {
-  return paragraphFields(comment, author, LinkType.COMMENT);
+function paragraphFromComment(comment: Entity): Partial<Paragraph> {
+  return paragraphFromEntity(comment, LinkType.COMMENT);
 }
 
-function paragraphFields(
+function paragraphFromEntity(
   entity: Entity,
-  author: Entity | undefined,
   linkType: LinkType,
 ): Partial<Paragraph> {
   const dateCreated = entity.dateCreated?.[0] as string | undefined;
-  const authorEmail = author?.email?.[0] as string | undefined;
   const keywords = entity.keywords?.[0] as string | undefined;
 
-  const tags = [`eln:id:${entity['@id']}`];
-  if (authorEmail) tags.push(`eln:author:${authorEmail}`);
-  if (dateCreated) tags.push(`eln:created:${dateCreated.slice(0, 10)}`);
+  const tags = provenanceTags(entity);
   if (keywords) tags.push(...keywords.split(','));
 
   return {
@@ -186,45 +150,50 @@ function filesnippetFromFile(file: Entity): Partial<Filesnippet> {
   };
 }
 
+// --- draft builders: ELN entity → draft node ---
+
+function buildLogbook(book: Entity): LogbookDraft {
+  return {
+    fields: logbookFromBook(book),
+    // Comments also appear in a Book's hasPart, but are built under their
+    // message via the `comment` field, so only messages are taken here.
+    paragraphs: partsOfType(book, 'Message').map(buildParagraph),
+  };
+}
+
+function buildParagraph(entity: Entity): ParagraphDraft {
+  return {
+    fields: entity.$$hasType('Comment')
+      ? paragraphFromComment(entity)
+      : paragraphFromMessage(entity),
+    files: partsOfType(entity, 'File').map(buildFile),
+    paragraphs: (entity.comment ?? []).map(buildParagraph),
+  };
+}
+
+function buildFile(file: Entity): FileDraft {
+  return {
+    elnId: file['@id'] as string,
+    fields: filesnippetFromFile(file),
+  };
+}
+
 // --- types ---
 
-/**
- * Drafts of entities to create from an .eln archive, grouped by SciLog kind.
- *
- * The orchestrator drives creation in declaration order: logbook first, then
- * files (all parented to the logbook), then paragraphs (which embed file
- * references via `hasPart` and recurse into `comment` for sub-comments).
- *
- * `hasPart` and `comment` carry the spec's relationship fields as plain
- * `@id` strings — references are resolved via the kind-specific Maps below.
- */
-export type ImportDraft = {
-  logbook: LogbookDraft;
-  files: Map<string, FileDraft>;
-  paragraphs: Map<string, ParagraphDraft>;
-  comments: Map<string, CommentDraft>;
-};
-
-/** Fields common to every draft. */
-type DraftBase = {
-  /** Child `@id`s from the entity's `hasPart` field. */
-  hasPart: string[];
-  /** Child `@id`s from the entity's schema.org `comment` field. */
-  comment: string[];
-};
-
-export type LogbookDraft = DraftBase & {
+export type LogbookDraft = {
   fields: Partial<Logbook>;
+  paragraphs: ParagraphDraft[];
 };
 
-export type ParagraphDraft = DraftBase & {
+export type ParagraphDraft = {
   fields: Partial<Paragraph>;
+  files: FileDraft[];
+  /** Paragraphs nested under this one; comments are the common case. */
+  paragraphs: ParagraphDraft[];
 };
 
-export type FileDraft = DraftBase & {
+export type FileDraft = {
+  /** Archive-relative `@id`; locates the file's bytes for upload. */
+  elnId: string;
   fields: Partial<Filesnippet>;
-};
-
-export type CommentDraft = DraftBase & {
-  fields: Partial<Paragraph>;
 };


### PR DESCRIPTION
A review comment on the import PR (https://github.com/paulscherrerinstitute/scilog/pull/635) suggested moving the service's
inline comment handling into a createComment method. But SciLog has no
"comment" concept: a comment is just a paragraph (linkType=comment), so
it should have been createParagraph.

The split only seemed natural because of the translator's output type.
toSciLog returned paragraphs, comments and files as separate @id-keyed
maps wired by raw hasPart/comment references — RO-Crate's shape — which
left every caller treating paragraphs and comments as different things
and rebuilding the tree from the `@id` links.

So the fix is the output type. toSciLog now returns a logbook with a
tree of paragraphs, each carrying its files and its nested comments.
Callers just walk the tree, and ro-crate link mode lets the translator
read author, hasPart and comment as real entities instead of chasing
`@ids`.

See: https://github.com/paulscherrerinstitute/scilog/pull/635