### PR TITLE
fix: include all attached files from ckeditor

### DIFF
--- a/scilog/src/app/logbook/core/add-content/add-content.component.spec.ts
+++ b/scilog/src/app/logbook/core/add-content/add-content.component.spec.ts
@@ -301,6 +301,15 @@ describe('AddContentComponent', () => {
     expect(message.files[0].fileHash).toEqual('myHash');
   });
 
+  it('should include every attached file, not just the most recent, when preparing a message', () => {
+    let linkMock =
+      '<p><a class="fileLink" href="file:hashA">fileA.pdf</a> <a class="fileLink" href="file:hashB">fileB.pdf</a></p>';
+    component.fileStorage = [{ fileHash: 'hashA' } as any, { fileHash: 'hashB' } as any];
+    component.prepareMessage(linkMock);
+    let fileHashes = component.notification.files.map((file) => file.fileHash);
+    expect(fileHashes).toEqual(['hashA', 'hashB']);
+  });
+
   it('should prepare subsnippets container for quotes', () => {
     component.notification = notificationMock;
     component.prepareSubsnippetsQuoteContainer();

--- a/scilog/src/app/logbook/core/add-content/add-content.component.ts
+++ b/scilog/src/app/logbook/core/add-content/add-content.component.ts
@@ -6,7 +6,7 @@ import {
   MatDialogActions,
   MatDialogClose,
 } from '@angular/material/dialog';
-import { ClassicEditor } from '../ckeditor/editor';
+import { ClassicEditor, FileAttachment } from '../ckeditor/editor';
 import { AddContentService } from '../add-content.service';
 import { ChangeStreamNotification } from '../changestreamnotification.model';
 import { LinkType } from '@model/paragraphs';
@@ -67,7 +67,7 @@ export class AddContentComponent implements OnInit, OnDestroy {
   subscriptions: Subscription[] = [];
   contentChanged: boolean = false;
   initialized: boolean = false;
-  prel_fileStorage: any[] = [];
+  fileStorage: FileAttachment[] = [];
   config: any = [];
   editor: any;
   lastEdit: { message?: string; tags?: string } = {};
@@ -204,15 +204,16 @@ export class AddContentComponent implements OnInit, OnDestroy {
   }
 
   onChange({ editor }: ChangeEvent) {
+    if (!editor) return;
     localStorage.setItem(`${this.message.id}_message`, editor.getData());
     this.contentChanged = true;
+    this.fileStorage = editor.fileAttachments ?? this.fileStorage;
   }
 
   editorChange(editor: any): any {
     if (this.initialized) {
       if (typeof editor != 'undefined') {
         const data = editor.getData();
-        this.prel_fileStorage = editor['prel_fileStorage'];
         this.changeChain(data);
       }
     }
@@ -239,10 +240,10 @@ export class AddContentComponent implements OnInit, OnDestroy {
   }
 
   prepareMessage(data: string) {
-    let notification = extractNotificationMessage(
-      data,
-      this.message?.files ? this.message.files : [],
-    );
+    let notification = extractNotificationMessage(data, [
+      ...(this.message?.files ?? []),
+      ...this.fileStorage,
+    ]);
     if (notification != null) {
       this.notification.textcontent = notification.textcontent;
       this.notification.files = notification.files;

--- a/scilog/src/app/logbook/core/ckeditor/editor.ts
+++ b/scilog/src/app/logbook/core/ckeditor/editor.ts
@@ -50,9 +50,15 @@ import {
 
 import { InsertFile } from './insert-file.plugin';
 
+export interface FileAttachment {
+  file: File;
+  fileHash: string;
+  fileExtension: string;
+}
+
 declare module 'ckeditor5' {
   interface Editor {
-    prel_filestorage?: { file: File; fileHash: string; fileExtension: string }[];
+    fileAttachments?: FileAttachment[];
   }
 }
 

--- a/scilog/src/app/logbook/core/ckeditor/insert-file.plugin.ts
+++ b/scilog/src/app/logbook/core/ckeditor/insert-file.plugin.ts
@@ -1,5 +1,6 @@
 import { Plugin, FileDialogButtonView, icons } from 'ckeditor5';
 import { v4 as uuid } from 'uuid';
+import type { FileAttachment } from './editor';
 
 export class InsertFile extends Plugin {
   init() {
@@ -26,12 +27,12 @@ export class InsertFile extends Plugin {
             editor.model.insertContent(link, editor.model.document.selection);
           });
           const fnameParts = file.name.split('.');
-          const fileStorage = {
+          const fileAttachment: FileAttachment = {
             file,
             fileHash: fnameHash,
             fileExtension: 'file/' + fnameParts[fnameParts.length - 1],
           };
-          editor.prel_filestorage = [fileStorage];
+          editor.fileAttachments = [...(editor.fileAttachments ?? []), fileAttachment];
         }
       });
 

--- a/scilog/src/app/logbook/widgets/logbook-item/logbook-item.component.ts
+++ b/scilog/src/app/logbook/widgets/logbook-item/logbook-item.component.ts
@@ -189,7 +189,6 @@ export class LogbookItemComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('snippetContainer') snippetContainerRef: ElementRef;
   @ViewChild('editor') editorRef: ElementRef;
   @ViewChild('contentEditor') editorContentRef: CKEditorComponent;
-  @ViewChild('contentEditor') editorContentComponentRef: QueryList<CKEditorComponent>;
   @ViewChild('tagEditor') tagEditorRef: TagEditorComponent;
   @ViewChild('searchSnippets') searchSnippetsRef: ElementRef;
 
@@ -922,16 +921,14 @@ export class LogbookItemComponent implements OnInit, AfterViewInit, OnDestroy {
 
   addContent(isMessage = false) {
     this.forceScrollToEnd = true;
-    console.log(this.editorContentRef.editorInstance.prel_filestorage);
     let notification: ChangeStreamNotification = extractNotificationMessage(
       this.editorContentRef.editorInstance.getData(),
-      this.editorContentRef.editorInstance.prel_filestorage,
+      this.editorContentRef.editorInstance.fileAttachments,
     );
 
     if (notification != null) {
       notification.parentId = this.targetId;
       notification.isMessage = isMessage;
-      // notification.files = this.editorContentRef.editorInstance.prel_filestorage;
       if (
         !this.modifiedMetadata &&
         this.childSnippets.last &&


### PR DESCRIPTION
Fixes #208 

Before, only the last attached file was actually sent to the server, as the [insert-file-plugin](https://github.com/paulscherrerinstitute/scilog/pull/648/changes#diff-1f431ef8ceea70204195d657e659ced89e243a6773ad2d315d105a1c253d93f3L34) overwrote the fileAttachments array, instead of appending to it. Fixing it now. 
Also renamed `prel_filestorage` to `fileAttachments` (not sure what `prel` meant).

This is a precursor to the fix for #643 , where we will sync the draft files (in addition to draft content, tags and images) across desktop and mobile layouts.