### PR TITLE
fix(api): pin chromium to bookworm/main 147

### DIFF
--- a/sci-log-db/Dockerfile
+++ b/sci-log-db/Dockerfile
@@ -8,8 +8,12 @@ WORKDIR /home/node/app
 
 RUN chown -R node:node .
 
+# Pinned: chromium 150 in bookworm-security crashes on startup
+# (Debian bug #1141488); 147 from bookworm/main predates the regression.
 RUN apt-get update && \
-    apt-get install -y chromium --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
+        chromium=147.0.7727.137-1~deb12u1 \
+        chromium-common=147.0.7727.137-1~deb12u1 && \
     rm -rf /var/lib/apt/lists/*
 
 ENV CHROME_BIN=/usr/bin/chromium


### PR DESCRIPTION
Headless Chrome fails to launch (SIGTRAP, surfaced by puppeteer as
"Code: null"), breaking PDF export wherever a freshly built image
runs, including production. It first showed up in CI because CI always
builds fresh; local builds were masked by a cached apt layer holding
an older chromium.

The image installs chromium from bookworm-security, which tracks the
latest upstream release; version 150 there crashes on startup even on
a raw command-line launch, on every architecture and immune to
sandbox, GPU, /dev/shm, and feature flags (Debian bug #1141488).

Pin to 147.0.7727.137-1~deb12u1 from bookworm/main, which predates the
regression and launches reliably (verified headless in a fresh
container). chromium-common is pinned to match, as chromium depends on
the exact version.