### PR TITLE
fix: move yauzl to runtime dependencies

### DIFF
--- a/sci-log-db/package-lock.json
+++ b/sci-log-db/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "sci-log-db",
       "version": "2.9.1",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@loopback/authentication": "12.0.13",
         "@loopback/authentication-jwt": "0.16.13",
@@ -33,7 +34,8 @@
         "ro-crate-html": "0.1.6",
         "tar": "7.5.13",
         "tslib": "2.0.0",
-        "ws": "8.20.0"
+        "ws": "8.20.0",
+        "yauzl": "3.2.1"
       },
       "devDependencies": {
         "@loopback/build": "12.0.11",
@@ -49,8 +51,7 @@
         "@types/ws": "8.18.1",
         "@types/yauzl": "2.10.3",
         "eslint": "8.57.1",
-        "typescript": "5.2.2",
-        "yauzl": "3.2.1"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": ">=10.16"
@@ -12817,7 +12818,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
       "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -12831,7 +12831,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"

--- a/sci-log-db/package.json
+++ b/sci-log-db/package.json
@@ -64,7 +64,8 @@
     "ro-crate-html": "0.1.6",
     "tar": "7.5.13",
     "tslib": "2.0.0",
-    "ws": "8.20.0"
+    "ws": "8.20.0",
+    "yauzl": "3.2.1"
   },
   "devDependencies": {
     "@loopback/build": "12.0.11",
@@ -80,7 +81,6 @@
     "@types/ws": "8.18.1",
     "@types/yauzl": "2.10.3",
     "eslint": "8.57.1",
-    "typescript": "5.2.2",
-    "yauzl": "3.2.1"
+    "typescript": "5.2.2"
   }
 }


### PR DESCRIPTION
`yauzl` is needed at runtime by `eln-archive.ts`, but was declared as a devDep leading to failure in CI, as devDeps are [omitted](https://github.com/paulscherrerinstitute/scilog/blob/main/sci-log-db/Dockerfile#L71) from the prod image: https://github.com/paulscherrerinstitute/scilog-ci/pull/152