### PR TITLE
feat(web): add ELN archive import to overview

### DIFF
--- a/scilog/src/app/core/remote-data.service.spec.ts
+++ b/scilog/src/app/core/remote-data.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
 import { RemoteDataService } from '@shared/remote-data.service';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { AppConfigService } from '../app-config.service';
 import {
   LogbookDataService,
@@ -355,6 +355,23 @@ describe('LogbookDataService', () => {
       limit: 20,
       skip: 10,
     });
+  });
+
+  it('should POST importELN as multipart with the location-id param', () => {
+    const httpTestingController = TestBed.inject(HttpTestingController);
+    const file = new File(['x'], 'archive.eln');
+
+    service.importELN(file, 'loc1');
+
+    const req = httpTestingController.expectOne(
+      (r) => r.url === 'http://[::1]:3000/logbooks/import/eln',
+    );
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.params.get('location-id')).toEqual('loc1');
+    expect(req.request.body instanceof FormData).toBeTrue();
+    expect((req.request.body as FormData).get('file')).toBe(file);
+    req.flush({ id: 'lb1' });
+    httpTestingController.verify();
   });
 });
 

--- a/scilog/src/app/core/remote-data.service.ts
+++ b/scilog/src/app/core/remote-data.service.ts
@@ -14,6 +14,7 @@ import { Views } from '@model/views';
 import { Images } from '@model/images';
 import _ from 'lodash';
 import { TagsStat } from '@model/tags';
+import { firstValueFrom } from 'rxjs';
 
 interface Count {
   count: number;
@@ -404,6 +405,18 @@ export class LogbookDataService extends RemoteDataService {
   postLogbook(payload: any): Promise<Logbooks> {
     const headers = new HttpHeaders().set('Content-Type', 'application/json');
     return this.postSnippet<Logbooks>('logbooks', JSON.stringify(payload), headers).toPromise();
+  }
+
+  importELN(file: File, locationId: string): Promise<Logbooks> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return firstValueFrom(
+      this.httpClient.post<Logbooks>(
+        `${this.serverSettings.getServerAddress()}logbooks/import/eln`,
+        formData,
+        { params: { 'location-id': locationId } },
+      ),
+    );
   }
 
   uploadLogbookThumbnail(formData: any, header: HttpHeaders = null): Promise<any> {

--- a/scilog/src/app/overview/import-eln/import-eln.component.css
+++ b/scilog/src/app/overview/import-eln/import-eln.component.css
@@ -1,0 +1,43 @@
+.drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 24px;
+  margin: 8px 0 16px;
+  border: 2px dashed rgba(0, 0, 0, 0.26);
+  border-radius: 4px;
+  color: rgba(0, 0, 0, 0.6);
+  text-align: center;
+  cursor: pointer;
+}
+
+.drop-zone.drag-over {
+  border-color: var(--accent-color);
+  background: rgba(0, 0, 0, 0.03);
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+.field-label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.field-label .required-marker {
+  color: var(--warn-color);
+}
+
+.import-errors {
+  margin-top: 12px;
+  color: var(--warn-color);
+}
+
+.import-errors ul {
+  margin: 4px 0 0;
+  padding-left: 20px;
+}

--- a/scilog/src/app/overview/import-eln/import-eln.component.html
+++ b/scilog/src/app/overview/import-eln/import-eln.component.html
@@ -1,0 +1,52 @@
+<h2 mat-dialog-title>Import logbook from .eln</h2>
+
+<mat-dialog-content>
+  @if (inProgress) {
+    <mat-progress-bar mode="query" color="accent"></mat-progress-bar>
+  }
+
+  <label class="field-label">
+    ELN file <span class="required-marker" aria-hidden="true">*</span>
+  </label>
+  <div
+    class="drop-zone"
+    [class.drag-over]="isDragging"
+    (click)="fileInput.click()"
+    (dragover)="onDragOver($event)"
+    (dragleave)="onDragLeave($event)"
+    (drop)="onDrop($event)"
+  >
+    <mat-icon>upload_file</mat-icon>
+    @if (file) {
+      <span>{{ file.name }}</span>
+    } @else {
+      <span>Drag a .eln file here, or click to browse (max {{ maxFileSizeMb }} MB)</span>
+    }
+  </div>
+  <input hidden type="file" accept=".eln" (change)="onFileSelected($event)" #fileInput />
+
+  <mat-form-field>
+    <mat-label>Location (Beamline or Instrument)</mat-label>
+    <mat-select [(value)]="locationId" required>
+      @for (location of availLocations; track location.id) {
+        <mat-option [value]="location.id">{{ location.location }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  @if (errors.length) {
+    <div class="import-errors">
+      <p>The archive could not be imported:</p>
+      <ul>
+        @for (error of errors; track error.code + error.message) {
+          <li>{{ error.message }}</li>
+        }
+      </ul>
+    </div>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close>Cancel</button>
+  <button mat-button (click)="importEln()" [disabled]="!canImport">Import</button>
+</mat-dialog-actions>

--- a/scilog/src/app/overview/import-eln/import-eln.component.spec.ts
+++ b/scilog/src/app/overview/import-eln/import-eln.component.spec.ts
@@ -1,0 +1,139 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Router } from '@angular/router';
+import { LogbookDataService } from '@shared/remote-data.service';
+import { SnackbarService } from '@shared/snackbar.service';
+import { ImportElnComponent } from './import-eln.component';
+
+function elnFile(name = 'archive.eln', size = 1024): File {
+  const file = new File(['x'], name);
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+}
+
+function selectFile(component: ImportElnComponent, file: File): void {
+  component.onFileSelected({ target: { files: [file] } } as unknown as Event);
+}
+
+describe('ImportElnComponent', () => {
+  const mockDialogRef = { close: jasmine.createSpy('close') };
+  let logbookDataSpy: jasmine.SpyObj<LogbookDataService>;
+  let snackBarSpy: jasmine.SpyObj<SnackbarService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  let component: ImportElnComponent;
+  let fixture: ComponentFixture<ImportElnComponent>;
+
+  beforeEach(waitForAsync(() => {
+    logbookDataSpy = jasmine.createSpyObj('LogbookDataService', ['getLocations', 'importELN']);
+    logbookDataSpy.getLocations.and.returnValue(
+      Promise.resolve([{ subsnippets: [{ id: 'loc1', location: 'Beamline 1' }] }]) as any,
+    );
+    snackBarSpy = jasmine.createSpyObj('SnackbarService', ['showSnackbarMessage']);
+    routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl']);
+
+    TestBed.configureTestingModule({
+      imports: [MatDialogModule, NoopAnimationsModule, ImportElnComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: LogbookDataService, useValue: logbookDataSpy },
+        { provide: SnackbarService, useValue: snackBarSpy },
+        { provide: Router, useValue: routerSpy },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ImportElnComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    mockDialogRef.close.calls.reset();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('loads the selectable locations on init', async () => {
+    await fixture.whenStable();
+    expect(component.availLocations).toEqual([{ id: 'loc1', location: 'Beamline 1' }] as any);
+  });
+
+  it('accepts a valid .eln file', () => {
+    selectFile(component, elnFile('good.eln'));
+    expect(component.file?.name).toBe('good.eln');
+    expect(snackBarSpy.showSnackbarMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-.eln file with a warning', () => {
+    selectFile(component, elnFile('notes.txt'));
+    expect(component.file).toBeNull();
+    expect(snackBarSpy.showSnackbarMessage).toHaveBeenCalledWith(jasmine.any(String), 'warning');
+  });
+
+  it('rejects a file larger than the limit', () => {
+    selectFile(component, elnFile('huge.eln', 101 * 1024 * 1024));
+    expect(component.file).toBeNull();
+    expect(snackBarSpy.showSnackbarMessage).toHaveBeenCalledWith(jasmine.any(String), 'warning');
+  });
+
+  it('canImport requires a file and a location', () => {
+    expect(component.canImport).toBeFalse();
+    selectFile(component, elnFile());
+    expect(component.canImport).toBeFalse();
+    component.locationId = 'loc1';
+    expect(component.canImport).toBeTrue();
+  });
+
+  it('imports, closes, and navigates to the new logbook on success', async () => {
+    logbookDataSpy.importELN.and.returnValue(Promise.resolve({ id: 'lb1' } as any));
+    const file = elnFile();
+    selectFile(component, file);
+    component.locationId = 'loc1';
+
+    await component.importEln();
+
+    expect(logbookDataSpy.importELN).toHaveBeenCalledWith(file, 'loc1');
+    expect(snackBarSpy.showSnackbarMessage).toHaveBeenCalledWith('Import successful', 'resolved');
+    expect(mockDialogRef.close).toHaveBeenCalledTimes(1);
+    expect(routerSpy.navigateByUrl).toHaveBeenCalledWith('/logbooks/lb1/dashboard');
+  });
+
+  it('renders 422 validation details and keeps the dialog open', async () => {
+    logbookDataSpy.importELN.and.returnValue(
+      Promise.reject({
+        error: {
+          error: { details: [{ code: 'INVALID_PUBLISHER', message: 'Not a SciLog export' }] },
+        },
+      }),
+    );
+    selectFile(component, elnFile());
+    component.locationId = 'loc1';
+
+    await component.importEln();
+
+    expect(component.errors).toEqual([
+      { code: 'INVALID_PUBLISHER', message: 'Not a SciLog export' },
+    ]);
+    expect(mockDialogRef.close).not.toHaveBeenCalled();
+    expect(routerSpy.navigateByUrl).not.toHaveBeenCalled();
+    expect(component.inProgress).toBeFalse();
+  });
+
+  it('shows a generic warning for a non-structured error', async () => {
+    logbookDataSpy.importELN.and.returnValue(Promise.reject(new Error('network')));
+    selectFile(component, elnFile());
+    component.locationId = 'loc1';
+
+    await component.importEln();
+
+    expect(component.errors).toEqual([]);
+    expect(mockDialogRef.close).not.toHaveBeenCalled();
+    expect(snackBarSpy.showSnackbarMessage).toHaveBeenCalledWith(jasmine.any(String), 'warning');
+    expect(component.inProgress).toBeFalse();
+  });
+});

--- a/scilog/src/app/overview/import-eln/import-eln.component.ts
+++ b/scilog/src/app/overview/import-eln/import-eln.component.ts
@@ -1,0 +1,134 @@
+import { Component, OnInit, inject } from '@angular/core';
+import {
+  MatDialogRef,
+  MatDialogTitle,
+  MatDialogContent,
+  MatDialogActions,
+  MatDialogClose,
+} from '@angular/material/dialog';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatSelect, MatOption } from '@angular/material/select';
+import { MatButton } from '@angular/material/button';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { MatIcon } from '@angular/material/icon';
+import { Router } from '@angular/router';
+import { Basesnippets } from '@model/basesnippets';
+import { LogbookDataService } from '@shared/remote-data.service';
+import { SnackbarService } from '@shared/snackbar.service';
+
+interface ElnError {
+  code: string;
+  message: string;
+}
+
+// Keep in sync with the backend limit (eln-import.config.ts: MAX_FILE_SIZE_MB).
+const MAX_FILE_SIZE_MB = 100;
+const MAX_FILE_SIZE = MAX_FILE_SIZE_MB * 1024 * 1024;
+
+@Component({
+  selector: 'app-import-eln',
+  templateUrl: './import-eln.component.html',
+  styleUrls: ['./import-eln.component.css'],
+  imports: [
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatProgressBar,
+    MatIcon,
+    MatFormField,
+    MatLabel,
+    MatSelect,
+    MatOption,
+    MatButton,
+  ],
+})
+export class ImportElnComponent implements OnInit {
+  private logbookDataService = inject(LogbookDataService);
+  private snackBar = inject(SnackbarService);
+  private dialogRef = inject<MatDialogRef<ImportElnComponent>>(MatDialogRef);
+  private router = inject(Router);
+
+  availLocations: Basesnippets[] = [];
+  locationId: string | null = null;
+  file: File | null = null;
+  inProgress = false;
+  isDragging = false;
+  errors: ElnError[] = [];
+
+  readonly maxFileSizeMb = MAX_FILE_SIZE_MB;
+
+  async ngOnInit(): Promise<void> {
+    const locations = await this.logbookDataService.getLocations();
+    this.availLocations = locations?.[0]?.subsnippets ?? [];
+  }
+
+  get canImport(): boolean {
+    return !!this.file && !!this.locationId && !this.inProgress;
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.setFile(input.files?.[0] ?? null);
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    this.isDragging = true;
+  }
+
+  onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    this.isDragging = false;
+  }
+
+  onDrop(event: DragEvent): void {
+    event.preventDefault();
+    this.isDragging = false;
+    this.setFile(event.dataTransfer?.files?.[0] ?? null);
+  }
+
+  private setFile(file: File | null): void {
+    if (!file) return;
+    if (!file.name.toLowerCase().endsWith('.eln')) {
+      this.snackBar.showSnackbarMessage('Please choose a .eln file.', 'warning');
+      return;
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      this.snackBar.showSnackbarMessage(
+        `File is too large (max ${MAX_FILE_SIZE_MB} MB).`,
+        'warning',
+      );
+      return;
+    }
+    this.file = file;
+    this.errors = [];
+  }
+
+  async importEln(): Promise<void> {
+    const { file, locationId } = this;
+    if (!file || !locationId || this.inProgress) return;
+    this.inProgress = true;
+    this.errors = [];
+    try {
+      const logbook = await this.logbookDataService.importELN(file, locationId);
+      this.snackBar.showSnackbarMessage('Import successful', 'resolved');
+      this.dialogRef.close();
+      this.router.navigateByUrl(`/logbooks/${logbook.id}/dashboard`);
+    } catch (err) {
+      const details = (err as { error?: { error?: { details?: ElnError[] } } })?.error?.error
+        ?.details;
+      if (details?.length) {
+        this.errors = details;
+        this.snackBar.showSnackbarMessage('The .eln archive could not be imported.', 'warning');
+      } else {
+        this.snackBar.showSnackbarMessage(
+          'Error while importing the logbook. If the error persists contact an administrator',
+          'warning',
+        );
+      }
+    } finally {
+      this.inProgress = false;
+    }
+  }
+}

--- a/scilog/src/app/overview/overview.component.html
+++ b/scilog/src/app/overview/overview.component.html
@@ -8,7 +8,15 @@
         ><mat-icon>view_headline</mat-icon></mat-button-toggle
       >
     </mat-button-toggle-group>
-    <button (click)="addCollectionLogbook('logbook')">Add logbook</button><br />
+    <button mat-flat-button color="primary" [matMenuTriggerFor]="addMenu">
+      Add logbook
+      <mat-icon iconPositionEnd>arrow_drop_down</mat-icon>
+    </button>
+    <mat-menu #addMenu>
+      <button mat-menu-item (click)="addCollectionLogbook('logbook')">New logbook</button>
+      <button mat-menu-item (click)="importEln()">Import from .eln</button>
+    </mat-menu>
+    <br />
     <mat-spinner *ngIf="!overviewComponent?.isLoaded" [@spinner] class="spinner"></mat-spinner>
     <app-overview-table
       *ngIf="matCardType === 'logbook-headline'"

--- a/scilog/src/app/overview/overview.component.ts
+++ b/scilog/src/app/overview/overview.component.ts
@@ -6,6 +6,7 @@ import { CollectionConfig, WidgetItemConfig } from '@model/config';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { AddCollectionComponent } from './add-collection/add-collection.component';
 import { AddLogbookComponent } from './add-logbook/add-logbook.component';
+import { ImportElnComponent } from './import-eln/import-eln.component';
 import { LogbookInfoService } from '@shared/logbook-info.service';
 import { CookiesService } from '@shared/cookies.service';
 import { animate, style, transition, trigger } from '@angular/animations';
@@ -13,6 +14,8 @@ import { OverviewTableComponent } from './overview-table/overview-table.componen
 import { OverviewScrollComponent } from './overview-scroll/overview-scroll.component';
 import { ToolbarComponent } from '../core/toolbar/toolbar.component';
 import { MatButtonToggleGroup, MatButtonToggle } from '@angular/material/button-toggle';
+import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
+import { MatButton } from '@angular/material/button';
 import { FormsModule } from '@angular/forms';
 import { MatIcon } from '@angular/material/icon';
 import { NgIf } from '@angular/common';
@@ -40,6 +43,10 @@ export type MatCardType = 'logbook-module' | 'logbook-headline';
   imports: [
     ToolbarComponent,
     MatButtonToggleGroup,
+    MatMenu,
+    MatMenuItem,
+    MatMenuTrigger,
+    MatButton,
     FormsModule,
     MatButtonToggle,
     MatIcon,
@@ -151,6 +158,14 @@ export class OverviewComponent implements OnInit, OnDestroy {
         await this.reloadData(result, 'add');
       }),
     );
+  }
+
+  importEln() {
+    const dialogConfig = new MatDialogConfig();
+    dialogConfig.autoFocus = true;
+    dialogConfig.disableClose = true;
+    // The dialog navigates to the imported logbook itself, so no afterClosed handling here.
+    this.dialog.open(ImportElnComponent, dialogConfig);
   }
 
   private _prepareConfig() {

--- a/scilog/src/styles/_colors.scss
+++ b/scilog/src/styles/_colors.scss
@@ -83,6 +83,9 @@ $default-text-color-dark: mat.m2-get-color-from-palette($scilog-colors-dark, A40
 $accent-color: #ff0000;
 $accent-color-dark: mat.m2-get-color-from-palette($scilog-colors-dark, 500);
 
+$warn-color: mat.m2-get-color-from-palette($scilog-colors-light, A700);
+$warn-color-dark: mat.m2-get-color-from-palette($scilog-colors-dark, A700);
+
 $button-accent: mat.m2-get-color-from-palette($scilog-colors-light, 500);
 $button-accent-dark: mat.m2-get-color-from-palette($scilog-colors-dark, 500);
 
@@ -170,6 +173,10 @@ $colors: (
   --accent-color: (
     $accent-color,
     $accent-color-dark,
+  ),
+  --warn-color: (
+    $warn-color,
+    $warn-color-dark,
   ),
   --button-accent: (
     $button-accent,


### PR DESCRIPTION
The API can import SciLog .eln archives (#635) but the web app had
no way to trigger it. Add an import dialog — drag-and-drop or file
picker plus a target-location select — that uploads the archive and
navigates to the created logbook, listing per-error validation
messages from the endpoint on failure.

The overview's "Add logbook" control becomes a menu offering "New
logbook" and "Import from .eln"; Angular Material has no split-button
component, so a menu button is the idiomatic pattern.

Add a --warn-color theme token so the dialog's error text references
a themed color rather than a hardcoded literal.

Close: #650
