### PR TITLE
fix(web): explain .eln files in import dialog

### DIFF
--- a/scilog/src/app/overview/import-eln/import-eln.component.css
+++ b/scilog/src/app/overview/import-eln/import-eln.component.css
@@ -32,6 +32,19 @@ mat-form-field {
   color: var(--warn-color);
 }
 
+.field-label .hint-link {
+  color: inherit;
+  vertical-align: middle;
+  text-decoration: none;
+}
+
+.field-label .hint-icon {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+  line-height: 16px;
+}
+
 .import-errors {
   margin-top: 12px;
   color: var(--warn-color);

--- a/scilog/src/app/overview/import-eln/import-eln.component.html
+++ b/scilog/src/app/overview/import-eln/import-eln.component.html
@@ -7,6 +7,16 @@
 
   <label class="field-label">
     ELN file <span class="required-marker" aria-hidden="true">*</span>
+    <a
+      class="hint-link"
+      href="https://the.elnconsortium.org"
+      target="_blank"
+      rel="noopener"
+      matTooltip="An .eln archive is a logbook exported from SciLog (Export → ELN), based on the ELN file format. Only SciLog exports can be imported."
+      aria-label="About .eln files"
+    >
+      <mat-icon class="hint-icon">help_outline</mat-icon>
+    </a>
   </label>
   <div
     class="drop-zone"

--- a/scilog/src/app/overview/import-eln/import-eln.component.ts
+++ b/scilog/src/app/overview/import-eln/import-eln.component.ts
@@ -11,6 +11,7 @@ import { MatSelect, MatOption } from '@angular/material/select';
 import { MatButton } from '@angular/material/button';
 import { MatProgressBar } from '@angular/material/progress-bar';
 import { MatIcon } from '@angular/material/icon';
+import { MatTooltip } from '@angular/material/tooltip';
 import { Router } from '@angular/router';
 import { Basesnippets } from '@model/basesnippets';
 import { LogbookDataService } from '@shared/remote-data.service';
@@ -36,6 +37,7 @@ const MAX_FILE_SIZE = MAX_FILE_SIZE_MB * 1024 * 1024;
     MatDialogClose,
     MatProgressBar,
     MatIcon,
+    MatTooltip,
     MatFormField,
     MatLabel,
     MatSelect,


### PR DESCRIPTION
The import dialog gave no indication of what an .eln file is or that
only SciLog exports are accepted, so a user could pick the wrong file
and discover the constraint only from a failed import. Add a help
icon whose tooltip describes the file in SciLog terms and links to
the ELN file format spec.

Typed as fix rather than feat: it adds only explanatory help to the
already-released import dialog, not new functionality, so it should
ship as a patch rather than a minor release.
