### PR TITLE
fix(api): load pdf export css from compiled dist

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,7 @@
     "node": ">=10.16"
   },
   "scripts": {
-    "build": "lb-tsc",
+    "build": "lb-tsc --copy-resources",
     "lint": "npm run prettier:check && npm run eslint",
     "lint:fix": "npm run eslint:fix && npm run prettier:fix",
     "prettier:cli": "lb-prettier \"**/*.ts\" \"**/*.js\"",
@@ -25,7 +25,7 @@
     "migrate": "node ./dist/migrate",
     "openapi-spec": "node ./dist/openapi-spec",
     "clean": "lb-clean dist *.tsbuildinfo .eslintcache",
-    "dev": "tsc && (tsc --watch & node --watch --enable-source-maps .)"
+    "dev": "npm run build && (tsc --watch & node --watch --enable-source-maps .)"
   },
   "repository": {
     "type": "git"

--- a/api/src/__tests__/unit/service.export-snippet.unit.ts
+++ b/api/src/__tests__/unit/service.export-snippet.unit.ts
@@ -7,8 +7,10 @@ import {LinkType, Paragraph} from '../../models';
 import {Server} from '@loopback/rest';
 import PDFMerger from 'pdf-merger-js';
 import puppeteer from 'puppeteer';
+import type {Browser, Page} from 'puppeteer';
 import fspromise from 'fs/promises';
 import fs from 'fs';
+import {isAbsolute} from 'path';
 
 describe('Export service unit', function (this: Suite) {
   let tests: string[] | string[][];
@@ -249,6 +251,30 @@ describe('Export service unit', function (this: Suite) {
       expect(htmlToPDF.callCount).to.be.eql(o);
       expect(exportFile).to.be.eql('dir/file.pdf');
     });
+  });
+
+  it('htmlToPDF loads pdf.css anchored at the module, not the cwd', async () => {
+    const addStyleTag = sandbox.stub().resolves();
+    const page: Partial<Page> = {
+      setDefaultNavigationTimeout: sandbox.stub(),
+      setContent: sandbox.stub().resolves(),
+      addStyleTag,
+      emulateMediaType: sandbox.stub().resolves(),
+      pdf: sandbox.stub().resolves(),
+    };
+    const browser = {
+      newPage: sandbox.stub().resolves(page),
+    } as unknown as Browser;
+
+    await exportService['htmlToPDF'](browser, 'file.pdf', '<html></html>');
+
+    const cssPath = addStyleTag.args
+      .map(([opts]) => opts.path)
+      .find(p => p?.endsWith('pdf.css'));
+
+    expect(cssPath).to.not.be.undefined();
+    expect(isAbsolute(cssPath)).to.be.true();
+    expect(fs.existsSync(cssPath)).to.be.true();
   });
 
   const countTest = [

--- a/api/src/services/export-snippets.service.ts
+++ b/api/src/services/export-snippets.service.ts
@@ -11,7 +11,7 @@ import {omit} from 'lodash';
 import {writeFile} from 'fs/promises';
 import {create as tarCreate} from 'tar';
 import {mkdirSync, existsSync} from 'fs';
-import {basename} from 'path';
+import {basename, join} from 'path';
 
 @bind({
   scope: BindingScope.TRANSIENT,
@@ -363,7 +363,7 @@ export class ExportService {
     const page = await browser.newPage();
     page.setDefaultNavigationTimeout(0);
     await page.setContent(htmlString);
-    await page.addStyleTag({path: 'src/services/pdf.css'});
+    await page.addStyleTag({path: join(__dirname, 'pdf.css')});
     await page.addStyleTag({
       path: `${
         process.env.NODE_PATH ?? 'node_modules'


### PR DESCRIPTION
PDF export loaded pdf.css via a path relative to the working
directory. lb-tsc does not copy non-TypeScript assets into dist,
and the production image ships only dist/, so the stylesheet was
absent at runtime and export failed with ENOENT (HTTP 500). It
only worked in dev because the source tree happened to sit next
to the process.

Resolve the stylesheet relative to the compiled module and copy
it into dist via lb-tsc --copy-resources, matching the __dirname
pattern used elsewhere. Route dev through build so the asset is
present locally too.
