### PR TITLE
docs: move book.json to honkit book root

### DIFF
--- a/docs/Operator/book.json
+++ b/docs/Operator/book.json
@@ -1,4 +1,0 @@
-{
-    "plugins": ["chapter-fold"],
-    "title": "SciLog Documentation"
-}

--- a/docs/book.json
+++ b/docs/book.json
@@ -1,0 +1,4 @@
+{
+    "title": "SciLog Documentation",
+    "plugins": ["chapter-fold"]
+}


### PR DESCRIPTION
The docs are built with `npx honkit build . docs` from `docs/`, so
HonKit resolves the book's config at `docs/`. The only book.json lived
at `docs/Operator/book.json`, a subdirectory HonKit does not read, so
the chapter-fold plugin and the "SciLog Documentation" title were never
applied to the built site. Move it to the book root so the config takes
effect.

Close: #657
