### PR TITLE
fix(web): drop legacy acl from paragraph patch

### DIFF
--- a/web/src/app/logbook/widgets/logbook-item/logbook-item.component.ts
+++ b/web/src/app/logbook/widgets/logbook-item/logbook-item.component.ts
@@ -603,8 +603,6 @@ export class LogbookItemComponent implements OnInit, AfterViewInit, OnDestroy {
     // I guess it should only take these variables if they are not defined in the msg...
     console.log('referenceEntry: ', referenceEntry);
     let payload: ChangeStreamNotification = {
-      ownerGroup: referenceEntry.ownerGroup,
-      accessGroups: referenceEntry.accessGroups,
       isPrivate: referenceEntry.isPrivate,
       tags: msg.tags,
       snippetType: 'paragraph',
@@ -614,7 +612,6 @@ export class LogbookItemComponent implements OnInit, AfterViewInit, OnDestroy {
     };
     if (msg.isMessage) {
       payload.isMessage = true;
-      payload.ownerGroup = this.userPreferences.userInfo.email;
     }
     return payload;
   }


### PR DESCRIPTION
Editing a paragraph re-sent the parent logbook's ownerGroup and
accessGroups in the PATCH body. Their presence makes the backend
recompute the paragraph's ACLs from the logbook, which requires the
editor to be a logbook admin and returns 404 for a normal member -
so a user could not edit a paragraph they had just created.

These fields were only ever echoed from the logbook, never set by the
user in the edit dialog, so dropping them removes no functionality.
The underlying backend ACL recompute still needs a proper fix.

Close: #666
