### PR TITLE
fix(api): unpin chromium in Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,12 +8,9 @@ WORKDIR /home/node/app
 
 RUN chown -R node:node .
 
-# Pinned: chromium 150 in bookworm-security crashes on startup
-# (Debian bug #1141488); 147 from bookworm/main predates the regression.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        chromium=147.0.7727.137-1~deb12u1 \
-        chromium-common=147.0.7727.137-1~deb12u1 && \
+        chromium && \
     rm -rf /var/lib/apt/lists/*
 
 ENV CHROME_BIN=/usr/bin/chromium


### PR DESCRIPTION
The exact version pin (147.0.7727.137-1~deb12u1) no longer resolves
on the live Debian mirror, so apt-get 404s and the image never
builds. The pin existed only to avoid a chromium 150.x startup crash
(Debian bug #1141488), which is now fixed upstream in 150.0.7871.100;
bookworm-security currently ships .124. Tracking bookworm-security
unpinned resolves the build failure and restores automatic security
updates for chromium.

Close: #665
