### PR TITLE
test(api): reorganize eln tests, rename scilog fixtures

### DIFF
--- a/api/src/__tests__/acceptance/eln-import.acceptance.ts
+++ b/api/src/__tests__/acceptance/eln-import.acceptance.ts
@@ -7,7 +7,7 @@ import {SciLogDbApplication} from '../..';
 import {Logbook, Paragraph} from '../../models';
 import {Filesnippet} from '../../models/file.model';
 import {ElnError, ElnErrorCode} from '../../services/eln/archive';
-import {buildElnZip, validElnCrate} from '../eln.helpers';
+import {buildElnZip, validScilogCrate} from '../eln.helpers';
 import {
   clearDatabase,
   createUserToken,
@@ -178,7 +178,7 @@ describe('Logbook .eln import', function (this: Suite) {
         new Map([
           [
             'ro-crate-metadata.json',
-            Buffer.from(JSON.stringify(validElnCrate().toJSON())),
+            Buffer.from(JSON.stringify(validScilogCrate().toJSON())),
           ],
         ]),
       );
@@ -213,7 +213,7 @@ describe('Logbook .eln import', function (this: Suite) {
     });
 
     it('returns 422 when a referenced file is missing from the zip', async () => {
-      const crate = validElnCrate();
+      const crate = validScilogCrate();
       crate.addEntity({
         '@id': './book/missing.jpg',
         '@type': 'File',
@@ -238,7 +238,7 @@ describe('Logbook .eln import', function (this: Suite) {
         .set('Authorization', 'Bearer ' + token)
         .attach('file', eln, 'missing-file.eln')
         .expect(422);
-      // Two errors: the default ./book/file.txt from validElnCrate is also
+      // Two errors: the default ./book/file.txt from validScilogCrate is also
       // absent from our entries map, plus our intended ./book/missing.jpg.
       expectArchiveValidationError(r.body.error, [
         {
@@ -255,7 +255,7 @@ describe('Logbook .eln import', function (this: Suite) {
     it('returns 422 when a file sha256 does not match the metadata', async () => {
       const content = Buffer.from('the actual bytes');
       const wrongSha = '0'.repeat(64);
-      const crate = validElnCrate();
+      const crate = validScilogCrate();
       crate.addEntity({
         '@id': './book/data.txt',
         '@type': 'File',
@@ -280,7 +280,7 @@ describe('Logbook .eln import', function (this: Suite) {
         .set('Authorization', 'Bearer ' + token)
         .attach('file', eln, 'bad-sha.eln')
         .expect(422);
-      // Two errors: the default ./book/file.txt from validElnCrate is also
+      // Two errors: the default ./book/file.txt from validScilogCrate is also
       // absent, plus the intended checksum mismatch on ./book/data.txt.
       expectArchiveValidationError(r.body.error, [
         {

--- a/api/src/__tests__/eln.helpers.ts
+++ b/api/src/__tests__/eln.helpers.ts
@@ -7,7 +7,7 @@ import {finished} from 'node:stream/promises';
 import {ROCrate} from 'ro-crate';
 
 // Minimal RO-Crate 1.2 + ELN graph that passes validation.
-export function validElnCrate(): ROCrate {
+export function validScilogCrate(): ROCrate {
   return new ROCrate(
     {
       '@context': 'https://w3id.org/ro/crate/1.2/context',
@@ -88,8 +88,8 @@ export function validElnCrate(): ROCrate {
 
 // Build a Map<string, Buffer> with valid metadata and matching file content,
 // suitable for passing to ElnArchive.parseRaw().
-export function validElnEntries(): Map<string, Buffer> {
-  const crate = validElnCrate();
+export function validScilogEntries(): Map<string, Buffer> {
+  const crate = validScilogCrate();
   const fileContent = Buffer.from('hello');
   const sha = crypto.createHash('sha256').update(fileContent).digest('hex');
   crate.setProperty('./book/file.txt', 'sha256', sha);

--- a/api/src/__tests__/unit/eln/archive.unit.ts
+++ b/api/src/__tests__/unit/eln/archive.unit.ts
@@ -7,16 +7,20 @@ import {
   ElnErrorCode,
   ElnParseFailure,
   ElnArchive,
-} from '../../services/eln/archive';
-import {buildElnZip, validElnCrate, validElnEntries} from '../eln.helpers';
+} from '../../../services/eln/archive';
+import {
+  buildElnZip,
+  validScilogCrate,
+  validScilogEntries,
+} from '../../eln.helpers';
 
 describe('ElnArchive.validateMetadata', () => {
   it('accepts a minimal valid metadata object', () => {
-    expect(ElnArchive.validateMetadata(validElnCrate())).to.be.empty();
+    expect(ElnArchive.validateMetadata(validScilogCrate())).to.be.empty();
   });
 
   it('rejects when sdPublisher is not a supported publisher', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.setProperty('ro-crate-metadata.json', 'sdPublisher', {
       '@id': 'https://example.org/unknown-eln',
     });
@@ -26,7 +30,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when sdPublisher is missing', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.deleteProperty('ro-crate-metadata.json', 'sdPublisher');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.MISSING_ELN_FIELD},
@@ -34,7 +38,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when sdPublisher entity is not found in crate', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     const id = 'https://github.com/paulscherrerinstitute/scilog';
     crate.deleteEntity(id);
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
@@ -43,7 +47,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when sdPublisher entity is not an Organization', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     const id = 'https://github.com/paulscherrerinstitute/scilog';
     crate.setProperty(id, '@type', 'Person');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
@@ -52,7 +56,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when sdPublisher entity is missing name', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     const id = 'https://github.com/paulscherrerinstitute/scilog';
     crate.deleteProperty(id, 'name');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
@@ -61,7 +65,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when sdPublisher entity is missing url', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     const id = 'https://github.com/paulscherrerinstitute/scilog';
     crate.deleteProperty(id, 'url');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
@@ -70,7 +74,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when conformsTo is missing from descriptor', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.deleteProperty('ro-crate-metadata.json', 'conformsTo');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.MISSING_ELN_FIELD},
@@ -78,7 +82,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when conformsTo is below RO-Crate 1.1', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.setProperty('ro-crate-metadata.json', 'conformsTo', {
       '@id': 'https://w3id.org/ro/crate/1.0',
     });
@@ -88,7 +92,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when a File entity is missing name', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.deleteProperty('./book/file.txt', 'name');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.MISSING_FILE_FIELD},
@@ -96,7 +100,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when a File entity is missing encodingFormat', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.deleteProperty('./book/file.txt', 'encodingFormat');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.MISSING_FILE_FIELD},
@@ -104,7 +108,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when a File entity is missing sha256', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.deleteProperty('./book/file.txt', 'sha256');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.MISSING_FILE_FIELD},
@@ -112,7 +116,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when a File entity is missing contentSize', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.deleteProperty('./book/file.txt', 'contentSize');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.MISSING_FILE_FIELD},
@@ -120,7 +124,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when a Dataset entity is missing author', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.deleteProperty('./book/', 'author');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.MISSING_DATASET_FIELD},
@@ -128,7 +132,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when a Dataset entity is missing name', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.deleteProperty('./book/', 'name');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.MISSING_DATASET_FIELD},
@@ -136,7 +140,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when author entity is not found', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.setProperty('./book/', 'author', {'@id': '#nonexistent'});
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.INVALID_AUTHOR},
@@ -144,7 +148,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when author entity is not a Person', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.setProperty('#author', '@type', 'Organization');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.INVALID_AUTHOR},
@@ -152,7 +156,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when author entity is missing email', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.deleteProperty('#author', 'email');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.INVALID_AUTHOR},
@@ -160,7 +164,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when hasPart references a non-existent entity', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.addValues('./book/', 'hasPart', {'@id': './does-not-exist/'});
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.INVALID_HAS_PART},
@@ -168,7 +172,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects when comment references a non-existent entity', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.addValues('./book/message/', 'comment', {'@id': './does-not-exist/'});
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.INVALID_COMMENT},
@@ -176,13 +180,13 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('accepts numeric contentSize', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.setProperty('./book/file.txt', 'contentSize', 123);
     expect(ElnArchive.validateMetadata(crate)).to.be.empty();
   });
 
   it('rejects contentSize with unit suffixes', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.setProperty('./book/file.txt', 'contentSize', '2.5MB');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.INVALID_CONTENT_SIZE},
@@ -190,7 +194,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects contentSize that is non-numeric', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.setProperty('./book/file.txt', 'contentSize', 'abc');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.INVALID_CONTENT_SIZE},
@@ -198,7 +202,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects contentSize that is negative', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.setProperty('./book/file.txt', 'contentSize', '-5');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.INVALID_CONTENT_SIZE},
@@ -206,7 +210,7 @@ describe('ElnArchive.validateMetadata', () => {
   });
 
   it('rejects contentSize that is empty', () => {
-    const crate = validElnCrate();
+    const crate = validScilogCrate();
     crate.setProperty('./book/file.txt', 'contentSize', '');
     expect(ElnArchive.validateMetadata(crate)).to.containDeep([
       {code: ElnErrorCode.INVALID_CONTENT_SIZE},
@@ -216,7 +220,7 @@ describe('ElnArchive.validateMetadata', () => {
 
 describe('ElnArchive.parseRaw', () => {
   it('returns ok for valid entries', () => {
-    const result = ElnArchive.parseRaw(validElnEntries());
+    const result = ElnArchive.parseRaw(validScilogEntries());
     expect(result.ok).to.be.true();
   });
 
@@ -262,12 +266,12 @@ describe('ElnArchive.parseRaw', () => {
   });
 
   it('accepts nested files under the same root folder', () => {
-    const result = ElnArchive.parseRaw(validElnEntries());
+    const result = ElnArchive.parseRaw(validScilogEntries());
     expect(result.ok).to.be.true();
   });
 
   it('resolves file IDs via getFile()', () => {
-    const result = ElnArchive.parseRaw(validElnEntries());
+    const result = ElnArchive.parseRaw(validScilogEntries());
     expect(result.ok).to.be.true();
     const elnArchive = (result as {ok: true; elnArchive: ElnArchive})
       .elnArchive;
@@ -277,7 +281,7 @@ describe('ElnArchive.parseRaw', () => {
   });
 
   it('returns undefined from getFile() for missing files', () => {
-    const result = ElnArchive.parseRaw(validElnEntries());
+    const result = ElnArchive.parseRaw(validScilogEntries());
     expect(result.ok).to.be.true();
     const elnArchive = (result as {ok: true; elnArchive: ElnArchive})
       .elnArchive;
@@ -285,7 +289,7 @@ describe('ElnArchive.parseRaw', () => {
   });
 
   it('returns correct hasFile() results', () => {
-    const result = ElnArchive.parseRaw(validElnEntries());
+    const result = ElnArchive.parseRaw(validScilogEntries());
     expect(result.ok).to.be.true();
     const elnArchive = (result as {ok: true; elnArchive: ElnArchive})
       .elnArchive;
@@ -296,7 +300,7 @@ describe('ElnArchive.parseRaw', () => {
 
 describe('ElnArchive#validateIntegrity', () => {
   it('accepts when file bytes match the declared sha256', () => {
-    const result = ElnArchive.parseRaw(validElnEntries());
+    const result = ElnArchive.parseRaw(validScilogEntries());
     expect(result.ok).to.be.true();
     const elnArchive = (result as {ok: true; elnArchive: ElnArchive})
       .elnArchive;
@@ -304,7 +308,7 @@ describe('ElnArchive#validateIntegrity', () => {
   });
 
   it('rejects when a referenced file is missing from the archive', () => {
-    const entries = validElnEntries();
+    const entries = validScilogEntries();
     entries.delete('root/book/file.txt');
     const result = ElnArchive.parseRaw(entries);
     expect(result.ok).to.be.true();
@@ -316,7 +320,7 @@ describe('ElnArchive#validateIntegrity', () => {
   });
 
   it('rejects when file sha256 does not match', () => {
-    const entries = validElnEntries();
+    const entries = validScilogEntries();
     entries.set('root/book/file.txt', Buffer.from('wrong content'));
     const result = ElnArchive.parseRaw(entries);
     expect(result.ok).to.be.true();
@@ -365,7 +369,7 @@ describe('ElnArchive.parse', () => {
   });
 
   it('returns ok for a valid .eln archive', async () => {
-    const filepath = await buildElnZip(validElnEntries());
+    const filepath = await buildElnZip(validScilogEntries());
     tmpFiles.push(filepath);
 
     const result = await ElnArchive.parse(filepath);
@@ -389,7 +393,7 @@ describe('ElnArchive.parse', () => {
   });
 
   it('surfaces integrity errors through the full pipeline', async () => {
-    const entries = validElnEntries();
+    const entries = validScilogEntries();
     entries.delete('root/book/file.txt');
     const filepath = await buildElnZip(entries);
     tmpFiles.push(filepath);

--- a/api/src/__tests__/unit/eln/translators/scilog.unit.ts
+++ b/api/src/__tests__/unit/eln/translators/scilog.unit.ts
@@ -1,11 +1,11 @@
 import {expect} from '@loopback/testlab';
-import {LinkType} from '../../models/paragraph.model';
-import {ScilogTranslator} from '../../services/eln/translators/scilog';
-import {validElnCrate} from '../eln.helpers';
+import {LinkType} from '../../../../models/paragraph.model';
+import {ScilogTranslator} from '../../../../services/eln/translators/scilog';
+import {validScilogCrate} from '../../../eln.helpers';
 
 describe('ScilogTranslator.toSciLog', () => {
   it('assembles the tree: one paragraph with its file and nested comment', () => {
-    const draft = ScilogTranslator.toSciLog(validElnCrate());
+    const draft = ScilogTranslator.toSciLog(validScilogCrate());
     expect(draft.paragraphs).to.have.length(1);
 
     const [message] = draft.paragraphs;
@@ -23,20 +23,22 @@ describe('ScilogTranslator.toSciLog', () => {
 
   describe('logbook', () => {
     it('extracts fields and provenance tags from the Book entity', () => {
-      expect(ScilogTranslator.toSciLog(validElnCrate()).fields).to.deepEqual({
-        name: 'book',
-        description: 'a book',
-        tags: [
-          'eln:source:scilog',
-          'eln:id:./book/',
-          'eln:author:a@example.org',
-          'eln:created:2026-01-19',
-        ],
-      });
+      expect(ScilogTranslator.toSciLog(validScilogCrate()).fields).to.deepEqual(
+        {
+          name: 'book',
+          description: 'a book',
+          tags: [
+            'eln:source:scilog',
+            'eln:id:./book/',
+            'eln:author:a@example.org',
+            'eln:created:2026-01-19',
+          ],
+        },
+      );
     });
 
     it('omits optional fields and conditional tags when missing', () => {
-      const crate = validElnCrate();
+      const crate = validScilogCrate();
       crate.deleteProperty('./book/', 'description');
       crate.deleteProperty('./book/', 'dateCreated');
       crate.deleteProperty('./book/', 'author');
@@ -50,7 +52,8 @@ describe('ScilogTranslator.toSciLog', () => {
 
   describe('paragraphs', () => {
     it('maps Message entity fields, with linkType=paragraph and split keyword tags', () => {
-      const [message] = ScilogTranslator.toSciLog(validElnCrate()).paragraphs;
+      const [message] =
+        ScilogTranslator.toSciLog(validScilogCrate()).paragraphs;
       expect(message.fields).to.deepEqual({
         linkType: LinkType.PARAGRAPH,
         textcontent: '<p>hello</p>',
@@ -68,7 +71,8 @@ describe('ScilogTranslator.toSciLog', () => {
 
   describe('files', () => {
     it('embeds File entity fields on the paragraph that references them', () => {
-      const [message] = ScilogTranslator.toSciLog(validElnCrate()).paragraphs;
+      const [message] =
+        ScilogTranslator.toSciLog(validScilogCrate()).paragraphs;
       expect(message.files).to.deepEqual([
         {
           elnId: './book/file.txt',
@@ -86,14 +90,14 @@ describe('ScilogTranslator.toSciLog', () => {
     });
 
     it('leaves fileExtension undefined when the name has no extension', () => {
-      const crate = validElnCrate();
+      const crate = validScilogCrate();
       crate.setProperty('./book/file.txt', 'name', 'README');
       const [message] = ScilogTranslator.toSciLog(crate).paragraphs;
       expect(message.files[0].fields.fileExtension).to.be.undefined();
     });
 
     it('embeds files on a comment, not only on a paragraph', () => {
-      const crate = validElnCrate();
+      const crate = validScilogCrate();
       crate.addEntity({
         '@id': './book/comment/img.png',
         '@type': 'File',
@@ -115,12 +119,14 @@ describe('ScilogTranslator.toSciLog', () => {
 
   describe('comments', () => {
     it('nests a message comments as child paragraphs', () => {
-      const [message] = ScilogTranslator.toSciLog(validElnCrate()).paragraphs;
+      const [message] =
+        ScilogTranslator.toSciLog(validScilogCrate()).paragraphs;
       expect(message.paragraphs).to.have.length(1);
     });
 
     it('maps Comment entity fields, with linkType=comment', () => {
-      const [message] = ScilogTranslator.toSciLog(validElnCrate()).paragraphs;
+      const [message] =
+        ScilogTranslator.toSciLog(validScilogCrate()).paragraphs;
       const [comment] = message.paragraphs;
       expect(comment.fields).to.deepEqual({
         linkType: LinkType.COMMENT,


### PR DESCRIPTION
The SciLog-specific fixtures (validElnCrate/validElnEntries) and the
translator unit test carried the generic "eln" name, though they
exercise SciLog's RO-Crate profile in particular — ambiguous now that
openBIS is a second ELN publisher.

Rename them validScilog* and move the eln unit tests under unit/eln/
(translators/scilog.unit.ts) mirroring the services/eln/ source layout,
so the growing test family maps 1:1 to source and the plain "eln" name
is reserved for the format-agnostic parts.
