### PR TITLE
refactor(api): introduce per-publisher translator seam

### DIFF
--- a/api/src/__tests__/unit/eln/archive.unit.ts
+++ b/api/src/__tests__/unit/eln/archive.unit.ts
@@ -16,16 +16,6 @@ describe('ElnArchive.validateMetadata', () => {
     expect(ElnArchive.validateMetadata(validScilogCrate())).to.be.empty();
   });
 
-  it('rejects when sdPublisher is not a supported publisher', () => {
-    const crate = validScilogCrate();
-    crate.setProperty('ro-crate-metadata.json', 'sdPublisher', {
-      '@id': 'https://example.org/unknown-eln',
-    });
-    expect(ElnArchive.validateMetadata(crate)).to.containDeep([
-      {code: ElnErrorCode.INVALID_PUBLISHER},
-    ]);
-  });
-
   it('rejects when sdPublisher is missing', () => {
     const crate = validScilogCrate();
     crate.deleteProperty('ro-crate-metadata.json', 'sdPublisher');

--- a/api/src/__tests__/unit/eln/translators/scilog.unit.ts
+++ b/api/src/__tests__/unit/eln/translators/scilog.unit.ts
@@ -3,9 +3,11 @@ import {LinkType} from '../../../../models/paragraph.model';
 import {ScilogTranslator} from '../../../../services/eln/translators/scilog';
 import {validScilogCrate} from '../../../eln.helpers';
 
+const translator = new ScilogTranslator();
+
 describe('ScilogTranslator.toSciLog', () => {
   it('assembles the tree: one paragraph with its file and nested comment', () => {
-    const draft = ScilogTranslator.toSciLog(validScilogCrate());
+    const draft = translator.toSciLog(validScilogCrate());
     expect(draft.paragraphs).to.have.length(1);
 
     const [message] = draft.paragraphs;
@@ -23,18 +25,16 @@ describe('ScilogTranslator.toSciLog', () => {
 
   describe('logbook', () => {
     it('extracts fields and provenance tags from the Book entity', () => {
-      expect(ScilogTranslator.toSciLog(validScilogCrate()).fields).to.deepEqual(
-        {
-          name: 'book',
-          description: 'a book',
-          tags: [
-            'eln:source:scilog',
-            'eln:id:./book/',
-            'eln:author:a@example.org',
-            'eln:created:2026-01-19',
-          ],
-        },
-      );
+      expect(translator.toSciLog(validScilogCrate()).fields).to.deepEqual({
+        name: 'book',
+        description: 'a book',
+        tags: [
+          'eln:source:scilog',
+          'eln:id:./book/',
+          'eln:author:a@example.org',
+          'eln:created:2026-01-19',
+        ],
+      });
     });
 
     it('omits optional fields and conditional tags when missing', () => {
@@ -42,7 +42,7 @@ describe('ScilogTranslator.toSciLog', () => {
       crate.deleteProperty('./book/', 'description');
       crate.deleteProperty('./book/', 'dateCreated');
       crate.deleteProperty('./book/', 'author');
-      expect(ScilogTranslator.toSciLog(crate).fields).to.deepEqual({
+      expect(translator.toSciLog(crate).fields).to.deepEqual({
         name: 'book',
         description: undefined,
         tags: ['eln:source:scilog', 'eln:id:./book/'],
@@ -52,8 +52,7 @@ describe('ScilogTranslator.toSciLog', () => {
 
   describe('paragraphs', () => {
     it('maps Message entity fields, with linkType=paragraph and split keyword tags', () => {
-      const [message] =
-        ScilogTranslator.toSciLog(validScilogCrate()).paragraphs;
+      const [message] = translator.toSciLog(validScilogCrate()).paragraphs;
       expect(message.fields).to.deepEqual({
         linkType: LinkType.PARAGRAPH,
         textcontent: '<p>hello</p>',
@@ -71,8 +70,7 @@ describe('ScilogTranslator.toSciLog', () => {
 
   describe('files', () => {
     it('embeds File entity fields on the paragraph that references them', () => {
-      const [message] =
-        ScilogTranslator.toSciLog(validScilogCrate()).paragraphs;
+      const [message] = translator.toSciLog(validScilogCrate()).paragraphs;
       expect(message.files).to.deepEqual([
         {
           elnId: './book/file.txt',
@@ -92,7 +90,7 @@ describe('ScilogTranslator.toSciLog', () => {
     it('leaves fileExtension undefined when the name has no extension', () => {
       const crate = validScilogCrate();
       crate.setProperty('./book/file.txt', 'name', 'README');
-      const [message] = ScilogTranslator.toSciLog(crate).paragraphs;
+      const [message] = translator.toSciLog(crate).paragraphs;
       expect(message.files[0].fields.fileExtension).to.be.undefined();
     });
 
@@ -109,7 +107,7 @@ describe('ScilogTranslator.toSciLog', () => {
       crate.addValues('./book/comment/', 'hasPart', {
         '@id': './book/comment/img.png',
       });
-      const [message] = ScilogTranslator.toSciLog(crate).paragraphs;
+      const [message] = translator.toSciLog(crate).paragraphs;
       const [comment] = message.paragraphs;
       expect(comment.files.map(file => file.elnId)).to.deepEqual([
         './book/comment/img.png',
@@ -119,14 +117,12 @@ describe('ScilogTranslator.toSciLog', () => {
 
   describe('comments', () => {
     it('nests a message comments as child paragraphs', () => {
-      const [message] =
-        ScilogTranslator.toSciLog(validScilogCrate()).paragraphs;
+      const [message] = translator.toSciLog(validScilogCrate()).paragraphs;
       expect(message.paragraphs).to.have.length(1);
     });
 
     it('maps Comment entity fields, with linkType=comment', () => {
-      const [message] =
-        ScilogTranslator.toSciLog(validScilogCrate()).paragraphs;
+      const [message] = translator.toSciLog(validScilogCrate()).paragraphs;
       const [comment] = message.paragraphs;
       expect(comment.fields).to.deepEqual({
         linkType: LinkType.COMMENT,
@@ -151,14 +147,14 @@ describe('ScilogTranslator.decodeFileReferences', () => {
 
   it('rewrites anchor href to file:<newFileHash>', () => {
     const html = '<p>see <a href="./book/message/file.txt">doc</a></p>';
-    expect(ScilogTranslator.decodeFileReferences(html, fileMap)).to.equal(
+    expect(translator.decodeFileReferences(html, fileMap)).to.equal(
       '<p>see <a href="file:newhash-1">doc</a></p>',
     );
   });
 
   it('rewrites img title to the new fileHash and leaves src as-is', () => {
     const html = '<p><img src="./book/message/img.png" title="oldhash"></p>';
-    expect(ScilogTranslator.decodeFileReferences(html, fileMap)).to.equal(
+    expect(translator.decodeFileReferences(html, fileMap)).to.equal(
       '<p><img src="./book/message/img.png" title="newhash-2"></p>',
     );
   });
@@ -167,7 +163,7 @@ describe('ScilogTranslator.decodeFileReferences', () => {
     const html =
       '<a href="./book/message/file.txt">f</a>' +
       '<img src="./book/message/img.png" title="x">';
-    expect(ScilogTranslator.decodeFileReferences(html, fileMap)).to.equal(
+    expect(translator.decodeFileReferences(html, fileMap)).to.equal(
       '<a href="file:newhash-1">f</a>' +
         '<img src="./book/message/img.png" title="newhash-2">',
     );
@@ -177,12 +173,12 @@ describe('ScilogTranslator.decodeFileReferences', () => {
     const html =
       '<a href="https://example.org">ext</a>' +
       '<img src="data:image/png;base64,abc" title="keep">';
-    expect(ScilogTranslator.decodeFileReferences(html, fileMap)).to.equal(html);
+    expect(translator.decodeFileReferences(html, fileMap)).to.equal(html);
   });
 
   it('throws when an ELN ref is missing from the map', () => {
     const html = '<a href="./book/message/missing.txt">x</a>';
-    expect(() => ScilogTranslator.decodeFileReferences(html, fileMap)).to.throw(
+    expect(() => translator.decodeFileReferences(html, fileMap)).to.throw(
       /no file map entry for href \.\/book\/message\/missing\.txt/,
     );
   });

--- a/api/src/__tests__/unit/eln/translators/translator.unit.ts
+++ b/api/src/__tests__/unit/eln/translators/translator.unit.ts
@@ -1,0 +1,50 @@
+import {expect} from '@loopback/testlab';
+import type {ROCrate} from 'ro-crate';
+import {ElnErrorCode, ElnImportError} from '../../../../services/eln/errors';
+import {TranslatorRegistry} from '../../../../services/eln/translators/translator';
+import type {Translator} from '../../../../services/eln/translators/translator';
+
+const crate = {} as ROCrate;
+
+function fake(source: string, matches: boolean): Translator {
+  return {
+    matches: () => matches,
+    toSciLog: () => ({fields: {name: source}, paragraphs: []}),
+    decodeFileReferences: () => '',
+  };
+}
+
+describe('TranslatorRegistry.select', () => {
+  it('returns the first translator whose matches accepts the crate', () => {
+    const first = fake('first', true);
+    const second = fake('second', true);
+    const registry = new TranslatorRegistry([first, second]);
+    expect(registry.select(crate)).to.equal(first);
+  });
+
+  it('skips translators that do not match', () => {
+    const skipped = fake('skipped', false);
+    const hit = fake('hit', true);
+    const registry = new TranslatorRegistry([skipped, hit]);
+    expect(registry.select(crate)).to.equal(hit);
+  });
+
+  it('throws INVALID_PUBLISHER when no translator matches', () => {
+    const registry = new TranslatorRegistry([
+      fake('a', false),
+      fake('b', false),
+    ]);
+
+    let error: unknown;
+    try {
+      registry.select(crate);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).to.be.instanceOf(ElnImportError);
+    expect((error as ElnImportError).errors).to.containDeep([
+      {code: ElnErrorCode.INVALID_PUBLISHER},
+    ]);
+  });
+});

--- a/api/src/services/eln/archive.ts
+++ b/api/src/services/eln/archive.ts
@@ -29,10 +29,6 @@ export type ElnParseResult = ElnParseSuccess | ElnParseFailure;
 
 const METADATA_FILENAME = 'ro-crate-metadata.json';
 
-const SUPPORTED_PUBLISHERS = [
-  'https://github.com/paulscherrerinstitute/scilog',
-];
-
 const SUPPORTED_RO_CRATE_VERSIONS = [
   'https://w3id.org/ro/crate/1.1',
   'https://w3id.org/ro/crate/1.2',
@@ -290,15 +286,6 @@ function validateSdPublisher(crate: ROCrate): ElnError[] {
   }
 
   const id = sdPublisher[0]?.['@id'];
-  if (!SUPPORTED_PUBLISHERS.includes(id)) {
-    return [
-      {
-        code: ElnErrorCode.INVALID_PUBLISHER,
-        message: `Unsupported sdPublisher: ${id}`,
-      },
-    ];
-  }
-
   const publisher = crate.getEntity(id);
   if (!publisher) {
     return [

--- a/api/src/services/eln/import.service.ts
+++ b/api/src/services/eln/import.service.ts
@@ -14,11 +14,12 @@ import {
 import {ElnArchive} from './archive';
 import {ElnImportError} from './errors';
 import {
-  ScilogTranslator,
   FileDraft,
   LogbookDraft,
   ParagraphDraft,
-} from './translators/scilog';
+  Translator,
+  translatorRegistry,
+} from './translators';
 import {FileStorageService} from '../file-storage.service';
 
 /** Per-file identity captured after creating the Filesnippet. */
@@ -56,11 +57,13 @@ export class ElnImportService {
     }
     if (!parsed.ok) throw new ElnImportError(parsed.errors);
 
-    const draft = ScilogTranslator.toSciLog(parsed.elnArchive.crate);
+    const translator = translatorRegistry.select(parsed.elnArchive.crate);
+    const draft = translator.toSciLog(parsed.elnArchive.crate);
     const logbookId = await this.createLogbook(
       draft,
       location,
       parsed.elnArchive,
+      translator,
     );
 
     return this.logbookRepository.findById(
@@ -74,6 +77,7 @@ export class ElnImportService {
     draft: LogbookDraft,
     location: Location,
     archive: ElnArchive,
+    translator: Translator,
   ): Promise<string> {
     const logbook = await this.logbookRepository.create(
       {
@@ -85,7 +89,7 @@ export class ElnImportService {
       {currentUser: this.user},
     );
     for (const paragraph of draft.paragraphs) {
-      await this.createParagraph(paragraph, logbook.id, archive);
+      await this.createParagraph(paragraph, logbook.id, archive, translator);
     }
     return logbook.id;
   }
@@ -94,18 +98,19 @@ export class ElnImportService {
     draft: ParagraphDraft,
     parentId: string,
     archive: ElnArchive,
+    translator: Translator,
   ): Promise<void> {
     const files = await this.createFiles(draft.files, archive);
     const html = draft.fields.textcontent;
     const textcontent = html
-      ? ScilogTranslator.decodeFileReferences(html, files)
+      ? translator.decodeFileReferences(html, files)
       : html;
     const created = await this.paragraphRepository.create(
       {...draft.fields, textcontent, files: [...files.values()], parentId},
       {currentUser: this.user},
     );
     for (const child of draft.paragraphs) {
-      await this.createParagraph(child, created.id, archive);
+      await this.createParagraph(child, created.id, archive, translator);
     }
   }
 

--- a/api/src/services/eln/translators/index.ts
+++ b/api/src/services/eln/translators/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Public entry point for the translator module: the contract types consumers
+ * need, plus the composed registry of the publishers SciLog supports.
+ *
+ * This barrel is the module's composition root — the one place that imports
+ * concrete translators. The translators themselves and the `TranslatorRegistry`
+ * class stay module-internal (import from `./translator` / `./scilog` directly
+ * if a test ever needs them).
+ */
+
+import {ScilogTranslator} from './scilog';
+import {TranslatorRegistry} from './translator';
+
+export type {
+  Translator,
+  LogbookDraft,
+  ParagraphDraft,
+  FileDraft,
+} from './translator';
+
+/** The publishers SciLog can import, most specific first. */
+export const translatorRegistry = new TranslatorRegistry([
+  new ScilogTranslator(),
+]);

--- a/api/src/services/eln/translators/scilog.ts
+++ b/api/src/services/eln/translators/scilog.ts
@@ -12,8 +12,20 @@ import {Entity, ROCrate} from 'ro-crate';
 import {Logbook, Paragraph} from '../../../models';
 import {Filesnippet} from '../../../models/file.model';
 import {LinkType} from '../../../models/paragraph.model';
+import type {
+  FileDraft,
+  LogbookDraft,
+  ParagraphDraft,
+  Translator,
+} from './translator';
 
-export class ScilogTranslator {
+const PUBLISHER = 'https://github.com/paulscherrerinstitute/scilog';
+
+export class ScilogTranslator implements Translator {
+  matches(crate: ROCrate): boolean {
+    return crate.descriptor.sdPublisher?.[0]?.['@id'] === PUBLISHER;
+  }
+
   /**
    * Translate ELN metadata into a SciLog logbook draft: a tree whose nodes
    * carry their embedded files and their nested paragraphs (a comment is a
@@ -21,7 +33,7 @@ export class ScilogTranslator {
    * orchestrator can fetch their bytes; the orchestrator assigns SciLog
    * identity (id, hashes) when it creates them.
    */
-  static toSciLog(crate: ROCrate): LogbookDraft {
+  toSciLog(crate: ROCrate): LogbookDraft {
     const book = findBook(crate);
     if (!book) throw new Error('ScilogTranslator: no Book entity in crate');
     return buildLogbook(book);
@@ -39,7 +51,7 @@ export class ScilogTranslator {
    * Throws if an `href`/`src` references a path absent from `fileMap` —
    * the orchestrator is contractually required to supply a complete map.
    */
-  static decodeFileReferences(
+  decodeFileReferences(
     html: string,
     fileMap: ReadonlyMap<string, {fileHash: string}>,
   ): string {
@@ -177,23 +189,3 @@ function buildFile(file: Entity): FileDraft {
     fields: filesnippetFromFile(file),
   };
 }
-
-// --- types ---
-
-export type LogbookDraft = {
-  fields: Partial<Logbook>;
-  paragraphs: ParagraphDraft[];
-};
-
-export type ParagraphDraft = {
-  fields: Partial<Paragraph>;
-  files: FileDraft[];
-  /** Paragraphs nested under this one; comments are the common case. */
-  paragraphs: ParagraphDraft[];
-};
-
-export type FileDraft = {
-  /** Archive-relative `@id`; locates the file's bytes for upload. */
-  elnId: string;
-  fields: Partial<Filesnippet>;
-};

--- a/api/src/services/eln/translators/translator.ts
+++ b/api/src/services/eln/translators/translator.ts
@@ -1,0 +1,69 @@
+/**
+ * The per-publisher translation seam for ELN import.
+ *
+ * An imported archive is a container (see `../archive`) whose crate follows one
+ * publisher's RO-Crate profile (SciLog, openBIS, ...). Each publisher has a
+ * `Translator` that recognises its crates and translates them into the shared
+ * `LogbookDraft`. The registry picks the translator whose `matches` accepts a
+ * given crate; the import service then persists the draft.
+ *
+ * This module is the contract only — it never imports a concrete translator.
+ * The composed registry lives in the barrel (`./index`).
+ */
+
+import type {ROCrate} from 'ro-crate';
+import type {Logbook, Paragraph} from '../../../models';
+import type {Filesnippet} from '../../../models/file.model';
+import {ElnErrorCode, ElnImportError} from '../errors';
+
+// --- canonical model (what every publisher's crate is translated into) ---
+
+export type LogbookDraft = {
+  fields: Partial<Logbook>;
+  paragraphs: ParagraphDraft[];
+};
+
+export type ParagraphDraft = {
+  fields: Partial<Paragraph>;
+  files: FileDraft[];
+  /** Paragraphs nested under this one; comments are the common case. */
+  paragraphs: ParagraphDraft[];
+};
+
+export type FileDraft = {
+  /** Archive-relative `@id`; locates the file's bytes for upload. */
+  elnId: string;
+  fields: Partial<Filesnippet>;
+};
+
+// --- the seam ---
+
+export interface Translator {
+  /** Cheap, side-effect-free check of whether this crate is our publisher's. */
+  matches(crate: ROCrate): boolean;
+  /** Translate the crate into the canonical draft. */
+  toSciLog(crate: ROCrate): LogbookDraft;
+  /** Rewrite in-HTML file references to the newly created file hashes. */
+  decodeFileReferences(
+    html: string,
+    fileMap: ReadonlyMap<string, {fileHash: string}>,
+  ): string;
+}
+
+/** Holds the supported translators and selects the one for a given crate. */
+export class TranslatorRegistry {
+  constructor(private readonly translators: Translator[]) {}
+
+  select(crate: ROCrate): Translator {
+    const translator = this.translators.find(t => t.matches(crate));
+    if (!translator) {
+      throw new ElnImportError([
+        {
+          code: ElnErrorCode.INVALID_PUBLISHER,
+          message: 'unsupported ELN source: no matching translator',
+        },
+      ]);
+    }
+    return translator;
+  }
+}


### PR DESCRIPTION
ELN import hardcoded SciLog's translation. To support additional publishers (openBIS) without branching the shared import pipeline, introduce a Translator interface + registry (Strategy pattern): each publisher recognises its own crates via matches() and translates them into the shared LogbookDraft. The import service selects a translator through the registry (select-or-fail), so "which publisher is supported" becomes the registry's decision — and the archive no longer checks the sdPublisher allow-list. Its other SciLog-profile checks stay in the container for now, until per-publisher validation is split out.

Behaviour-preserving for SciLog; the canonical draft types move from scilog.ts into the translator contract.

Threading the selected translator (and the archive) through the persistence helpers is a temporary measure: a follow-up makes the draft self-contained so persistence needs neither, and the threading is removed then.
