### PR TITLE
refactor(api): co-locate eln error types in an errors module

### DIFF
--- a/api/src/__tests__/acceptance/eln-import.acceptance.ts
+++ b/api/src/__tests__/acceptance/eln-import.acceptance.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import {SciLogDbApplication} from '../..';
 import {Logbook, Paragraph} from '../../models';
 import {Filesnippet} from '../../models/file.model';
-import {ElnError, ElnErrorCode} from '../../services/eln/archive';
+import {ElnError, ElnErrorCode} from '../../services/eln/errors';
 import {buildElnZip, validScilogCrate} from '../eln.helpers';
 import {
   clearDatabase,

--- a/api/src/__tests__/unit/eln/archive.unit.ts
+++ b/api/src/__tests__/unit/eln/archive.unit.ts
@@ -3,11 +3,8 @@ import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import {
-  ElnErrorCode,
-  ElnParseFailure,
-  ElnArchive,
-} from '../../../services/eln/archive';
+import {ElnArchive, ElnParseFailure} from '../../../services/eln/archive';
+import {ElnErrorCode} from '../../../services/eln/errors';
 import {
   buildElnZip,
   validScilogCrate,

--- a/api/src/controllers/eln-import.controller.ts
+++ b/api/src/controllers/eln-import.controller.ts
@@ -16,8 +16,8 @@ import {errors as formidableErrors, formidable} from 'formidable';
 import {Logbook} from '../models';
 import {LocationRepository} from '../repositories';
 import {basicAuthorization} from '../services/basic.authorizor';
-import {ElnError} from '../services/eln/archive';
-import {ElnImportError, ElnImportService} from '../services/eln/import.service';
+import {ElnError, ElnImportError} from '../services/eln/errors';
+import {ElnImportService} from '../services/eln/import.service';
 import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 import {MAX_FILE_SIZE} from './eln-import.config';
 import {

--- a/api/src/controllers/specs/eln-import.specs.ts
+++ b/api/src/controllers/specs/eln-import.specs.ts
@@ -1,6 +1,6 @@
 import {getModelSchemaRef, RequestBodyObject} from '@loopback/rest';
 import {Logbook} from '../../models';
-import {ElnErrorCode} from '../../services/eln/archive';
+import {ElnErrorCode} from '../../services/eln/errors';
 import {MAX_FILE_SIZE, MAX_FILE_SIZE_MB} from '../eln-import.config';
 
 const ERROR_SCHEMA = {

--- a/api/src/services/eln/archive.ts
+++ b/api/src/services/eln/archive.ts
@@ -9,33 +9,9 @@ import crypto from 'node:crypto';
 import {buffer} from 'node:stream/consumers';
 import {ROCrate} from 'ro-crate';
 import yauzl from 'yauzl';
+import {ElnError, ElnErrorCode} from './errors';
 
 // --- types ---
-
-export const ElnErrorCode = {
-  MISSING_ELN_FIELD: 'MISSING_ELN_FIELD',
-  INVALID_CONFORMS_TO: 'INVALID_CONFORMS_TO',
-  INVALID_PUBLISHER: 'INVALID_PUBLISHER',
-  MISSING_FILE_FIELD: 'MISSING_FILE_FIELD',
-  MISSING_DATASET_FIELD: 'MISSING_DATASET_FIELD',
-  INVALID_AUTHOR: 'INVALID_AUTHOR',
-  INVALID_HAS_PART: 'INVALID_HAS_PART',
-  INVALID_COMMENT: 'INVALID_COMMENT',
-  INVALID_CONTENT_SIZE: 'INVALID_CONTENT_SIZE',
-  INVALID_ELN_ARCHIVE: 'INVALID_ELN_ARCHIVE',
-  INVALID_ELN_STRUCTURE: 'INVALID_ELN_STRUCTURE',
-  MISSING_ELN_METADATA: 'MISSING_ELN_METADATA',
-  INVALID_ELN_METADATA: 'INVALID_ELN_METADATA',
-  MISSING_ELN_FILE: 'MISSING_ELN_FILE',
-  INVALID_ELN_CHECKSUM: 'INVALID_ELN_CHECKSUM',
-} as const;
-
-export type ElnErrorCode = (typeof ElnErrorCode)[keyof typeof ElnErrorCode];
-
-export type ElnError = {
-  code: ElnErrorCode;
-  message: string;
-};
 
 export type ElnParseSuccess = {
   ok: true;

--- a/api/src/services/eln/errors.ts
+++ b/api/src/services/eln/errors.ts
@@ -1,0 +1,38 @@
+/**
+ * The ELN import error vocabulary, shared by the container parser
+ * (`./archive`), the translators, and the import orchestration
+ * (`./import.service`).
+ */
+
+export const ElnErrorCode = {
+  MISSING_ELN_FIELD: 'MISSING_ELN_FIELD',
+  INVALID_CONFORMS_TO: 'INVALID_CONFORMS_TO',
+  INVALID_PUBLISHER: 'INVALID_PUBLISHER',
+  MISSING_FILE_FIELD: 'MISSING_FILE_FIELD',
+  MISSING_DATASET_FIELD: 'MISSING_DATASET_FIELD',
+  INVALID_AUTHOR: 'INVALID_AUTHOR',
+  INVALID_HAS_PART: 'INVALID_HAS_PART',
+  INVALID_COMMENT: 'INVALID_COMMENT',
+  INVALID_CONTENT_SIZE: 'INVALID_CONTENT_SIZE',
+  INVALID_ELN_ARCHIVE: 'INVALID_ELN_ARCHIVE',
+  INVALID_ELN_STRUCTURE: 'INVALID_ELN_STRUCTURE',
+  MISSING_ELN_METADATA: 'MISSING_ELN_METADATA',
+  INVALID_ELN_METADATA: 'INVALID_ELN_METADATA',
+  MISSING_ELN_FILE: 'MISSING_ELN_FILE',
+  INVALID_ELN_CHECKSUM: 'INVALID_ELN_CHECKSUM',
+} as const;
+
+export type ElnErrorCode = (typeof ElnErrorCode)[keyof typeof ElnErrorCode];
+
+export type ElnError = {
+  code: ElnErrorCode;
+  message: string;
+};
+
+/** Thrown to signal a failed import, carrying the validation errors. */
+export class ElnImportError extends Error {
+  constructor(readonly errors: ElnError[]) {
+    super(`ELN import failed with ${errors.length} error(s)`);
+    this.name = 'ElnImportError';
+  }
+}

--- a/api/src/services/eln/import.service.ts
+++ b/api/src/services/eln/import.service.ts
@@ -11,7 +11,8 @@ import {
   LogbookRepository,
   ParagraphRepository,
 } from '../../repositories';
-import {ElnArchive, ElnError} from './archive';
+import {ElnArchive} from './archive';
+import {ElnImportError} from './errors';
 import {
   ScilogTranslator,
   FileDraft,
@@ -19,13 +20,6 @@ import {
   ParagraphDraft,
 } from './translators/scilog';
 import {FileStorageService} from '../file-storage.service';
-
-export class ElnImportError extends Error {
-  constructor(readonly errors: ElnError[]) {
-    super(`ELN import failed with ${errors.length} error(s)`);
-    this.name = 'ElnImportError';
-  }
-}
 
 /** Per-file identity captured after creating the Filesnippet. */
 type CreatedFile = Required<


### PR DESCRIPTION
The eln error types lived where they were produced: ElnError and
ElnErrorCode in archive.ts (the parser was the only validator), and
ElnImportError in import.service.ts.

This is prep work: validation is about to stop being archive-only —
different translators (SciLog, openBIS) have different validation needs
and will each produce their own errors — and the translator registry
will need to throw ElnImportError. None of those can import the error
vocabulary from the parser or the service without an awkward
dependency (a cycle, in the registry's case). Move the vocabulary into
a neutral errors module so the upcoming translator-side validation and
registry can depend on it cleanly.

The parse-result types (ElnParse*) stay in archive.ts as they are
specific to ElnArchive.parse. Behaviour-preserving; no new consumers
yet.
