### PR TITLE
fix: only show link/unlink button when user belongs to ds's ownerGroup

### DIFF
--- a/web/src/app/core/scicat.service.ts
+++ b/web/src/app/core/scicat.service.ts
@@ -6,14 +6,14 @@ import {
   OutputDatasetObsoleteDto,
   ProposalsService,
   RelationshipClass,
-  ReturnedUserDto,
+  UserIdentity,
   UsersService,
 } from '@scicatproject/scicat-sdk-ts-angular';
 import { HttpContext, HttpContextToken } from '@angular/common/http';
 
 export type Dataset = OutputDatasetObsoleteDto;
 export type DatasetSummary = Pick<Dataset, 'pid' | 'datasetName' | 'creationTime'>;
-export type ScicatUser = ReturnedUserDto;
+export type ScicatUser = UserIdentity;
 type RelationshipSchema = RelationshipClass & { _id: string };
 
 export const IF_UNMODIFIED_SINCE = new HttpContextToken<string>(() => undefined);
@@ -44,7 +44,7 @@ export class ScicatService {
   }
 
   getMyself(): Observable<ScicatUser> {
-    return this.usersService.usersControllerGetMyUserV3() as Observable<ScicatUser>;
+    return this.usersService.usersControllerGetMyUserIdentityV3() as Observable<ScicatUser>;
   }
 
   getDatasetDetailPageUrl(pid: string): string {

--- a/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.html
+++ b/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="scicatUser; else unauthenticated">
-  <p>Hello, {{ scicatUser.username }}!</p>
+  <p>Hello, {{ scicatUser.profile.displayName || scicatUser.profile.username }}!</p>
 </div>
 <ng-template #unauthenticated>
   <p>Not authenticated with SciCat, showing only public datasets:</p>
@@ -65,14 +65,16 @@
       <a mat-button [href]="scicatDatasetUrl" target="_blank"
         >Open in SciCat <mat-icon>open_in_new</mat-icon></a
       >
-      @if (isUserLinkedDataset(selectedDataset.pid)) {
-        <button mat-button matTooltip="Unlink logbook from dataset" (click)="unlinkLogbook()">
-          <mat-icon>link_off</mat-icon> Unlink
-        </button>
-      } @else {
-        <button mat-button matTooltip="Link logbook to dataset" (click)="linkLogbook()">
-          <mat-icon>add_link</mat-icon> Link
-        </button>
+      @if (hasWriteAccess(selectedDataset)) {
+        @if (isUserLinkedDataset(selectedDataset.pid)) {
+          <button mat-button matTooltip="Unlink logbook from dataset" (click)="unlinkLogbook()">
+            <mat-icon>link_off</mat-icon> Unlink
+          </button>
+        } @else {
+          <button mat-button matTooltip="Link logbook to dataset" (click)="linkLogbook()">
+            <mat-icon>add_link</mat-icon> Link
+          </button>
+        }
       }
     </mat-card-actions>
   </mat-card>

--- a/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.spec.ts
+++ b/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ScicatViewerComponent } from './scicat-viewer.component';
-import { Dataset, ScicatService } from '@shared/scicat.service';
+import { Dataset, ScicatService, ScicatUser } from '@shared/scicat.service';
 import { of } from 'rxjs';
 import { LogbookInfoService } from '@shared/logbook-info.service';
 import { Logbooks } from '@model/logbooks';
@@ -170,6 +170,38 @@ describe('ScicatViewerComponent', () => {
       });
     });
   });
+  describe('hasWriteAccess', () => {
+    const dataset = { pid: '1', ownerGroup: 'group1' } as Dataset;
+
+    it('returns false when the scicat user is not available i.e. not logged in', () => {
+      scicatServiceSpy.getMyself.and.returnValue(of(null));
+
+      component.ngOnInit();
+
+      expect(component.hasWriteAccess(dataset)).toBeFalse();
+    });
+
+    it('returns true when the user access groups include the dataset owner group', () => {
+      scicatServiceSpy.getMyself.and.returnValue(
+        of({ profile: { accessGroups: ['group2', 'group1'] } } as ScicatUser),
+      );
+
+      component.ngOnInit();
+
+      expect(component.hasWriteAccess(dataset)).toBeTrue();
+    });
+
+    it('returns false when the user access groups do not include the dataset owner group', () => {
+      scicatServiceSpy.getMyself.and.returnValue(
+        of({ profile: { accessGroups: ['group2'] } } as ScicatUser),
+      );
+
+      component.ngOnInit();
+
+      expect(component.hasWriteAccess(dataset)).toBeFalse();
+    });
+  });
+
   describe('unlinkLogbook', () => {
     it('removes pid from userLinkedPids on success', () => {
       scicatServiceSpy.getDatasetsSummary.and.returnValue(

--- a/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.ts
+++ b/web/src/app/logbook/widgets/scicat-viewer/scicat-viewer.component.ts
@@ -139,6 +139,11 @@ export class ScicatViewerComponent implements OnInit {
     return this.userLinkedPids().has(pid);
   }
 
+  hasWriteAccess(dataset: Dataset): boolean {
+    if (!this.scicatUser) return false;
+    return this.scicatUser.profile.accessGroups.includes(dataset.ownerGroup);
+  }
+
   get scicatDatasetUrl(): string {
     return this.scicatService.getDatasetDetailPageUrl(this.selectedDataset?.pid);
   }


### PR DESCRIPTION
Fixes https://psich.atlassian.net/browse/DATACGRP-895

- To get user attributes, changed the call to scicat backend from `/api/v3/users/my/self` to `/api/v3/users/my/identity`, as it also includes user's `accessGroups`
-  Only showing the link / unlink button if ds's ownerGroup is included in user's accessGroups
- Note that this won't work for admin users, who implicitly have write permission on the DS regardless of ds's ownerGroup. If this needs to be supported in future, we can configure an env var `SCICAT_PRIVILEGED_GROUPS` and always show the link/unlink button to user's from these groups. Or wait for scicat to include an endpoint that lets us check write authorization for a DS. (But this case does not occur in the normal flow, as the SSO is only supported for OIDC users.)