### PR TITLE
fix(api): await restoreDeletedId in snippet controllers

### DIFF
--- a/api/src/controllers/basesnippet.controller.ts
+++ b/api/src/controllers/basesnippet.controller.ts
@@ -280,6 +280,6 @@ export class BasesnippetController {
     },
   })
   async restoreDeletedId(@param.path.string('id') id: string): Promise<void> {
-    this.basesnippetRepository.restoreDeletedId(id, this.user);
+    await this.basesnippetRepository.restoreDeletedId(id, this.user);
   }
 }

--- a/api/src/controllers/location.controller.ts
+++ b/api/src/controllers/location.controller.ts
@@ -241,6 +241,6 @@ export class LocationController {
     },
   })
   async restoreDeletedId(@param.path.string('id') id: string): Promise<void> {
-    this.locationRepository.restoreDeletedId(id, this.user);
+    await this.locationRepository.restoreDeletedId(id, this.user);
   }
 }

--- a/api/src/controllers/logbook.controller.ts
+++ b/api/src/controllers/logbook.controller.ts
@@ -255,6 +255,6 @@ export class LogbookController {
     },
   })
   async restoreDeletedId(@param.path.string('id') id: string): Promise<void> {
-    this.logbookRepository.restoreDeletedId(id, this.user);
+    await this.logbookRepository.restoreDeletedId(id, this.user);
   }
 }

--- a/api/src/controllers/paragraph.controller.ts
+++ b/api/src/controllers/paragraph.controller.ts
@@ -243,6 +243,6 @@ export class ParagraphController {
     },
   })
   async restoreDeletedId(@param.path.string('id') id: string): Promise<void> {
-    this.paragraphRepository.restoreDeletedId(id, this.user);
+    await this.paragraphRepository.restoreDeletedId(id, this.user);
   }
 }

--- a/api/src/controllers/task.controller.ts
+++ b/api/src/controllers/task.controller.ts
@@ -242,6 +242,6 @@ export class TaskController {
     },
   })
   async restoreDeletedId(@param.path.string('id') id: string): Promise<void> {
-    this.taskRepository.restoreDeletedId(id, this.user);
+    await this.taskRepository.restoreDeletedId(id, this.user);
   }
 }


### PR DESCRIPTION
The snippet controllers called an async restore operation without awaiting it, so the response could return before the restore finished and any failure became an unhandled rejection. This awaits the call.