### PR TITLE
fix(api): set nosniff and attachment headers on downloads

### DIFF
--- a/api/src/__tests__/acceptance/file.controller.acceptance.ts
+++ b/api/src/__tests__/acceptance/file.controller.acceptance.ts
@@ -354,8 +354,9 @@ describe('File controller services', function (this: Suite) {
       .set('Authorization', 'Bearer ' + token)
       .expect(200)
       .then(result => {
-        expect(result.text).to.startWith('"use strict"');
-        expect(result.type).to.eql('application/javascript');
+        expect(result.type).to.eql('application/octet-stream');
+        expect(result.header['content-disposition']).to.eql('attachment');
+        expect(result.header['x-content-type-options']).to.eql('nosniff');
       })
       .catch(err => {
         throw err;

--- a/api/src/controllers/file.controller.ts
+++ b/api/src/controllers/file.controller.ts
@@ -294,7 +294,14 @@ export class FileController {
     if (typeof data._fileId == 'undefined') {
       throw new HttpErrors.BadRequest(`Retrieving sandbox data is deprecated.`);
     }
-    response.set('Content-Type', data.contentType);
+    response.set(
+      'Content-Type',
+      data.contentType?.startsWith('image/')
+        ? data.contentType
+        : 'application/octet-stream',
+    );
+    response.set('X-Content-Type-Options', 'nosniff');
+    response.set('Content-Disposition', 'attachment');
     this.fileStorage.downloadStream(data._fileId).pipe(response);
     return response;
   }

--- a/api/src/controllers/image.controller.ts
+++ b/api/src/controllers/image.controller.ts
@@ -38,7 +38,14 @@ export class ImageController {
     const bucket = new Mongo.GridFSBucket(
       this.fileRepository.dataSource.connector?.db,
     );
-    response.set('Content-Type', data.contentType);
+    response.set(
+      'Content-Type',
+      data.contentType?.startsWith('image/')
+        ? data.contentType
+        : 'application/octet-stream',
+    );
+    response.set('X-Content-Type-Options', 'nosniff');
+    response.set('Content-Disposition', 'attachment');
     bucket.openDownloadStream(data._fileId).pipe(response);
     return response;
   }


### PR DESCRIPTION
Uploaded files were served inline with their stored content type, so an uploaded html or svg file could execute script when opened through its link. This serves non image content as an attachment and adds nosniff.