### PR TITLE
fix(api): reject operator keys in snippet update body

### DIFF
--- a/api/src/mixins/basesnippet.repository-mixin.ts
+++ b/api/src/mixins/basesnippet.repository-mixin.ts
@@ -63,6 +63,9 @@ function UpdateAndDeleteRepositoryMixin<
       options?: Options,
       checkExpiration = true,
     ): Promise<void> {
+      if (Object.keys(basesnippet).some(key => key.startsWith('$'))) {
+        throw new HttpErrors.BadRequest('Invalid operator in request body.');
+      }
       const baseSnippetRepository = await this.baseSnippetRepository();
       const snippet = await baseSnippetRepository.findById(id, {}, options);
       const patches = await this.applyFromOwnerAccessAndGetChanged(


### PR DESCRIPTION
The history aware update fed the request body straight into the update, so a top level mongo operator key in the body could reach the connector. This rejects operator keys in the update body.